### PR TITLE
Build binaries within Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,34 @@
+FROM mirror.gcr.io/library/golang:1.18 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor/ vendor/
+
+# Copy the go source
+COPY main.go main.go
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+COPY hack/ hack/
+
+# Build
+RUN hack/build-binaries.sh
+
+# Create image
 FROM registry.ci.openshift.org/ocp/4.12:tools
 RUN yum install -y skopeo gdisk && \
     yum clean -y all
-RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest/oc-mirror.tar.gz | tar xvzf - -C /usr/local/bin && chmod +x /usr/local/bin/oc-mirror
-COPY _output /usr/local/bin
+RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest/oc-mirror.tar.gz \
+    | tar xvzf - -C /usr/local/bin && \
+    chmod +x /usr/local/bin/oc-mirror
+
 COPY run.sh /run.sh
 COPY help.sh /help.sh
+
+COPY --from=builder /workspace/_output/ /usr/local/bin/
+
 # no tool is more important than others
 ENTRYPOINT ["/run.sh"]
 CMD ["/help.sh"]

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -1,10 +1,34 @@
+FROM mirror.gcr.io/library/golang:1.18 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor/ vendor/
+
+# Copy the go source
+COPY main.go main.go
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+COPY hack/ hack/
+
+# Build
+RUN hack/build-binaries.sh
+
+# Create image
 FROM fedora:latest
 RUN dnf install -y skopeo gdisk util-linux xfsprogs && \
     dnf clean -y all
-RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest/oc-mirror.tar.gz | tar xvzf - -C /usr/local/bin && chmod +x /usr/local/bin/oc-mirror
-COPY _output /usr/local/bin
+RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest/oc-mirror.tar.gz \
+    | tar xvzf - -C /usr/local/bin && \
+    chmod +x /usr/local/bin/oc-mirror
+
 COPY run.sh /run.sh
 COPY help.sh /help.sh
+
+COPY --from=builder /workspace/_output/ /usr/local/bin/
+
 # no tool is more important than others
 ENTRYPOINT ["/run.sh"]
 CMD ["/help.sh"]

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ clean:
 	rm -rf _output
 
 .PHONY: image
-image: binaries
+image:
 	@echo "building image"
 	$(RUNTIME) build -f Dockerfile -t quay.io/$(REPOOWNER)/$(IMAGENAME):$(IMAGETAG) .
 


### PR DESCRIPTION
Updated Dockerfile to build binaries in builder image first, then copy
into final image in secondary stage.

Signed-off-by: Don Penney <dpenney@redhat.com>