### PR TITLE
Fix oc-mirror unit tests

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    reviewers:
+      - telco-ran-tools-reviewers
+    approvers:
+      - telco-ran-tools-approvers
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  telco-ran-tools-reviewers:
+    - browsell
+    - donpenney
+    - rcarrillocruz
+    - nishant-parekh
+  telco-ran-tools-approvers:
+    - browsell
+    - donpenney
+    - rcarrillocruz
+    - nishant-parekh

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
 func TestGenerateOcMirrorCommand(t *testing.T) {
 	c := generateOcMirrorCommand("/tmp/fp-cli-lol")
-	want := "/usr/local/bin/oc-mirror -c /tmp/fp-cli-lol/imageset.yaml file:///tmp/fp-cli-lol/mirror --ignore-history --dry-run"
+	want := "-c /tmp/fp-cli-lol/imageset.yaml file:///tmp/fp-cli-lol/mirror --ignore-history --dry-run"
 
-	if c.String() != want {
+	if strings.Join(c.Args[1:], " ") != want {
 		t.Errorf("got %s, want %s", c, want)
 	}
 }


### PR DESCRIPTION
Since oc-mirror is not installed by default, we need to assert
the command args without the command itself