### PR TITLE
Add missing tags to AI images on ImageSet

### DIFF
--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -11,6 +11,6 @@ mirror:
       minVersion: {{ .Version }}
       maxVersion: {{ .Version }}
   additionalImages:
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-rhel8
+    - name: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8:v2.0
+    - name: registry.redhat.io/multicluster-engine/assisted-installer-rhel8:v2.0
 `


### PR DESCRIPTION
Latest can't be used, oc-mirror will spit out an error.