### PR TITLE
Only install DU on if 4.10 and fix rootfs already present check

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -150,12 +150,13 @@ func download(folder, release string) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	_, err = os.Stat(folder + "/rhcos-live-rootfs.x86_64.img")
+	_, err = os.Stat(folder + "rhcos-live-rootfs.x86_64.img")
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "Downloading release rootFS image...\n")
-		downloadRootFsFile(release, folder)
+		err = downloadRootFsFile(release, folder)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: unable to download rootFS image: %v", err)
+			fmt.Fprintf(os.Stderr, "error: unable to download rootFS image: %v\n", err)
+			os.Exit(1)
 		}
 	}
 

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -13,36 +13,37 @@ mirror:
   additionalImages:
     - name: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8:v2.0
     - name: registry.redhat.io/multicluster-engine/assisted-installer-rhel8:v2.0
- # Commenting operators section because in 4.11 some of them are not published yet
- # operators:
- #   - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}
- #     full: true
- #     packages:
- #       - name: odf-lvm-operator
- #         channels:
- #           - name: 'stable-{{ .Channel }}'
- #       - name: performance-addon-operator
- #         channels:
- #           - name: '{{ .Channel }}'
- #       - name: ptp-operator
- #         channels:
- #           - name: 'stable'
- #       - name: sriov-network-operator
- #         channels:
- #           - name: 'stable'
- #       - name: cluster-logging
- #         channels:
- #           - name: 'stable'
- #       - name: ocs-operator
- #         channels:
- #           - name: 'stable-{{ .Channel }}'
- #       - name: local-storage-operator
- #         channels:
- #           - name: 'stable'
- #   - catalog: registry.redhat.io/redhat/certified-operator-index:v{{ .Channel }}
- #     full: true
- #     packages:
- #       - name: sriov-fec
- #         channels:
- #           - name: 'stable'
+{{- if eq .Channel "4.10" }}
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}
+      full: true
+      packages:
+        - name: odf-lvm-operator
+          channels:
+            - name: 'stable-{{ .Channel }}'
+        - name: performance-addon-operator
+          channels:
+            - name: '{{ .Channel }}'
+        - name: ptp-operator
+          channels:
+            - name: 'stable'
+        - name: sriov-network-operator
+          channels:
+            - name: 'stable'
+        - name: cluster-logging
+          channels:
+            - name: 'stable'
+        - name: ocs-operator
+          channels:
+            - name: 'stable-{{ .Channel }}'
+        - name: local-storage-operator
+          channels:
+            - name: 'stable'
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v{{ .Channel }}
+      full: true
+      packages:
+        - name: sriov-fec
+          channels:
+            - name: 'stable'
+{{- end }}
 `


### PR DESCRIPTION
The rootfs already present check was failing as it was not getting the
error return from downloadRootFs function.
The 4.11 DU operators are still not all of them present in mirrors,thus
only template them if 4.10.
This check will be removed when 4.11 DU is out.