### PR TITLE
Hardcode AI images sha on ImageSet

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -38,8 +38,10 @@ func init() {
 }
 
 type ImageSet struct {
-	Channel string
-	Version string
+	Channel                   string
+	Version                   string
+	AssistedInstallerAgentSHA string
+	AssistedInstallerSHA      string
 }
 
 func generateOcMirrorCommand(tmpDir, folder string) *exec.Cmd {
@@ -80,7 +82,11 @@ func templatizeImageset(release, folder string) {
 	channel := r[0] + "." + r[1]
 	version := release
 
-	d := ImageSet{channel, version}
+	// This correspond to what we empirically saw AI 2.5 pulls, which do not correspond to published images with label 2.0 (ACM 2.5==MCE2.0), thus we hardcode
+	// till we figure out a better way. If we support ACM 2.6, then there should be a map of ACM versions => SHAs
+	assistedInstallerAgentSHA := "sha256:482618e19dc48990bb53f46e441ce21f574c04a6e0b9ee8fe1103284e15db994"
+	assistedInstallerSHA := "sha256:e0dbc04261a5f9d946d05ea40117b6c3ab33c000ae256e062f7c3e38cdf116cc"
+	d := ImageSet{channel, version, assistedInstallerAgentSHA, assistedInstallerSHA}
 	err = t.Execute(f, d)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: unable to execute template: %v\n", err)

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -11,8 +11,8 @@ mirror:
       minVersion: {{ .Version }}
       maxVersion: {{ .Version }}
   additionalImages:
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8:v2.0
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-rhel8:v2.0
+    - name: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@{{ .AssistedInstallerAgentSHA }}
+    - name: registry.redhat.io/multicluster-engine/assisted-installer-rhel8@{{ .AssistedInstallerSHA }}
 {{- if eq .Channel "4.10" }}
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}


### PR DESCRIPTION
The SHA of the images that we empirically figured that AI uses
do not correspond to the ones that oc-mirror/skopeo/opm uses.
So it seems that AI has hardcoded SHAs for those images, and then
they pushed newer versions to registry sharing same labels and
versions  with no bump.
Therefore, hardcoding the SHAs to match AI in practice till we
figure out a proper and maintainable way to infer them.