### PR TITLE
Remove partition/device size validation

### DIFF
--- a/cmd/partition_test.go
+++ b/cmd/partition_test.go
@@ -1,39 +1,8 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 )
-
-func TestIsPartitionSizeTooBig(t *testing.T) {
-	var tests = []struct {
-		a, b float64
-		want bool
-	}{
-		{float64(120), float64(100), false},
-		{float64(120), float64(120), false},
-		{float64(120), float64(121), true},
-	}
-
-	for _, tt := range tests {
-		testname := fmt.Sprintf("%f,%f", tt.a, tt.b)
-		t.Run(testname, func(t *testing.T) {
-			ans := isPartitionSizeTooBig(tt.a, tt.b)
-			if ans != tt.want {
-				t.Errorf("got %t, want %t", ans, tt.want)
-			}
-		})
-	}
-}
-
-func TestGenerateGetDeviceSizeCommand(t *testing.T) {
-	c := generateGetDeviceSizeCommand("/dev/lol")
-	want := "/usr/bin/lsblk /dev/lol -osize -dn"
-
-	if c.String() != want {
-		t.Errorf("got %s, want %s", c, want)
-	}
-}
 
 func TestGeneratePartitionCommand(t *testing.T) {
 	c := generatePartitionCommand("/dev/lol", 100)


### PR DESCRIPTION
Since we are using os.Exec to call sgdisk to partition the device,
sgdisk will regardless print out an error message if there is not enough
space in the disk for the desired partition size, thus removing the
code.