### PR TITLE
Add parameter for choosing rootFS

### DIFF
--- a/cmd/partition.go
+++ b/cmd/partition.go
@@ -31,10 +31,6 @@ func init() {
 
 }
 
-func isPartitionSizeTooBig(deviceSize, desiredSize float64) bool {
-	return desiredSize > deviceSize
-}
-
 func generatePartitionCommand(device string, size int) *exec.Cmd {
 	return exec.Command("sgdisk", "-n", fmt.Sprintf("1:-%dGiB:0", size), device, "-g", "-c:1:data")
 }


### PR DESCRIPTION
Turns out in some cases ACM/AI may not use the latest rhcos rootfs
for a given version, thus allow user to specify to user