### PR TITLE
Add options for AI and additional images

### DIFF
--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -13,6 +13,12 @@ mirror:
   additionalImages:
     - name: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@{{ .AssistedInstallerAgentSHA }}
     - name: registry.redhat.io/multicluster-engine/assisted-installer-rhel8@{{ .AssistedInstallerSHA }}
+{{- if ne .AssistedInstallerControllerSHA "" }}
+    - name: registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@{{ .AssistedInstallerControllerSHA }}
+{{- end }}
+{{- range $img := .AdditionalImages }}
+    - name: {{ $img }}
+{{- end }}
 {{- if eq .Channel "4.10" }}
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}


### PR DESCRIPTION
Added options to support specifying SHAs for Assisted Installer images, using optional --ai-installer-sha, --ai-agent-sha, and --ai-controller-sha options. In addition, added --img option to allow user to specify additional images, either with multiple --img options or comma-separated lists.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @browsell 