### PR TITLE
Add --rm-stale option and make robustness changes

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -57,8 +57,8 @@ func init() {
 type ImageSet struct {
 	Channel                        string
 	Version                        string
-	AssistedInstallerAgentSHA      string
 	AssistedInstallerSHA           string
+	AssistedInstallerAgentSHA      string
 	AssistedInstallerControllerSHA string
 	AdditionalImages               []string
 }
@@ -294,7 +294,7 @@ func download(folder, release, url, aiInstallerSha, aiAgentSha, aiControllerSha 
 		} else {
 			scratchdir := path.Join(folder, "scratch")
 			_, err = os.Stat(scratchdir)
-			if err != nil {
+			if err == nil {
 				err = os.RemoveAll(scratchdir)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "error: unable to remove directory %s: %e\n", path.Join(folder, image.Artifact), err)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rcarrillocruz/factory-precaching-cli
+module github.com/openshift-kni/telco-ran-tools
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 */
 package main
 
-import "github.com/rcarrillocruz/factory-precaching-cli/cmd"
+import "github.com/openshift-kni/telco-ran-tools/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
- Adding a --rm-stale option to request deletion of .tgz files in the working dir that do not correspond to images in the generated mapping.txt file
- Always regenerate mapping.txt and image list files
- Download image and generate tarfile in scratch dir under working dir, moving tarfile to working dir once fully written
- Update image list files after image tarfile is written

/cc @browsell @alosadagrande

