### PR TITLE
Add options for AI images and imageset generation

### DIFF
--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -11,11 +11,6 @@ mirror:
       minVersion: {{ .Version }}
       maxVersion: {{ .Version }}
   additionalImages:
-    - name: {{ .AIAgentImage }}
-    - name: {{ .AIInstallerImage }}
-{{- if ne .AIControllerImage "" }}
-    - name: {{ .AIControllerImage }}
-{{- end }}
 {{- range $img := .AdditionalImages }}
     - name: {{ $img }}
 {{- end }}

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -11,14 +11,30 @@ mirror:
       minVersion: {{ .Version }}
       maxVersion: {{ .Version }}
   additionalImages:
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@{{ .AssistedInstallerAgentSHA }}
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-rhel8@{{ .AssistedInstallerSHA }}
-{{- if ne .AssistedInstallerControllerSHA "" }}
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@{{ .AssistedInstallerControllerSHA }}
+    - name: {{ .AIAgentImage }}
+    - name: {{ .AIInstallerImage }}
+{{- if ne .AIControllerImage "" }}
+    - name: {{ .AIControllerImage }}
 {{- end }}
 {{- range $img := .AdditionalImages }}
     - name: {{ $img }}
 {{- end }}
+#
+# Example operators specification:
+#
+#  operators:
+#    - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}
+#      full: true
+#      packages:
+#        - name: ptp-operator
+#          channels:
+#            - name: 'stable'
+#        - name: sriov-network-operator
+#          channels:
+#            - name: 'stable'
+#        - name: cluster-logging
+#          channels:
+#            - name: 'stable'
 {{- if eq .Channel "4.10" }}
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}


### PR DESCRIPTION
Added options to allow the user to specify the full image reference for the Assisted Installer images, not just the SHA. This allows the user to override the default image location/name.

Added optional parameters to generate the imageset.yaml as a separate step, allowing the user to add to or modify the imageset.yaml file as needed before using that file for oc-mirror.
  --generate-imageset will generate the imageset.yaml and halt
  --skip-imageset will continue the download using the
already-generated imageset.yaml

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @browsell @alosadagrande 