### PR TITLE
Fixes formatting for nvme or disks that ends in a number

### DIFF
--- a/cmd/partition.go
+++ b/cmd/partition.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -36,7 +37,16 @@ func generatePartitionCommand(device string, size int) *exec.Cmd {
 }
 
 func generateFormatCommand(device string) *exec.Cmd {
-	return exec.Command("mkfs.xfs", "-f", device+"1")
+	// if device ends with a number a 'p' is included in the partition name
+	val, err := strconv.Atoi(device[len(device)-1:])
+	_ = val
+	if err != nil {
+		fmt.Printf("Partition %s1 is being formatted\n", device)
+		return exec.Command("mkfs.xfs", "-f", device+"1")
+	} else {
+		fmt.Printf("Partition %sp1 is being formatted\n", device)
+		return exec.Command("mkfs.xfs", "-f", device+"p1")
+	}
 }
 
 func partition(device string, size int) {


### PR DESCRIPTION
This code fixes the problem when formatting disks that end with a number instead of a string. In those cases, a 'p' + the number of the partition needs to be added to know what partition needs to be formatted after being parted.

Fixes #42 
Signed-off-by: Alberto Losada <alosadag@redhat.com>