### PR TITLE
fixes multi architecture containers fail when loading with skopeo

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -74,7 +74,8 @@ func generateOcMirrorCommand(tmpDir, folder string) *exec.Cmd {
 }
 
 func generateSkopeoCopyCommand(folder, artifact, artifactsFile string) *exec.Cmd {
-	return exec.Command("skopeo", "copy", "docker://"+artifactsFile, "dir://"+folder+"/"+artifact, "-q", "--retry-times", "10")
+	// copies container images from registry to local disk. Notice --all arg copies all architectures for a multi-arch container image
+	return exec.Command("skopeo", "copy", "--all", "docker://"+artifactsFile, "dir://"+folder+"/"+artifact, "-q", "--retry-times", "10")
 }
 
 func generateTarArtifactCommand(folder, artifact string) *exec.Cmd {

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -18,7 +18,7 @@ func TestGenerateSkopeoCopyCommand(t *testing.T) {
 	c := generateSkopeoCopyCommand("/tmp/mnt",
 		"assisted-installer-agent-rhel8@sha256_54f7376e521a3b22ddeef63623fc7256addf62a9323fa004c7f48efa7388fe39",
 		"registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:54f7376e521a3b22ddeef63623fc7256addf62a9323fa004c7f48efa7388fe39")
-	want := "copy docker://registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:54f7376e521a3b22ddeef63623fc7256addf62a9323fa004c7f48efa7388fe39 dir:///tmp/mnt/assisted-installer-agent-rhel8@sha256_54f7376e521a3b22ddeef63623fc7256addf62a9323fa004c7f48efa7388fe39 -q --retry-times 10"
+	want := "copy --all docker://registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:54f7376e521a3b22ddeef63623fc7256addf62a9323fa004c7f48efa7388fe39 dir:///tmp/mnt/assisted-installer-agent-rhel8@sha256_54f7376e521a3b22ddeef63623fc7256addf62a9323fa004c7f48efa7388fe39 -q --retry-times 10"
 
 	if strings.Join(c.Args[1:], " ") != want {
 		t.Errorf("got %s, want %s", c, want)


### PR DESCRIPTION
Fixes #45 

By adding the --all argument to skopeo it will pull all architecture images from the same container image. It will download and extract more data into the container-storage location.  We expect that skopeo includes an architecture flag for pulling only the right container image for our deployment.

Signed-off-by: Alberto Losada <alosadag@redhat.com>