### PR TITLE
Add build info as --version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,9 @@
 FROM mirror.gcr.io/library/golang:1.18 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY vendor/ vendor/
 
-# Copy the go source
-COPY main.go main.go
-COPY cmd/ cmd/
-COPY pkg/ pkg/
-
-COPY hack/ hack/
+# Copy full workspace for git version info
+COPY . .
 
 # Build
 RUN hack/build-binaries.sh

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,17 +1,9 @@
 FROM mirror.gcr.io/library/golang:1.18 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY vendor/ vendor/
 
-# Copy the go source
-COPY main.go main.go
-COPY cmd/ cmd/
-COPY pkg/ pkg/
-
-COPY hack/ hack/
+# Copy full workspace for git version info
+COPY . .
 
 # Build
 RUN hack/build-binaries.sh

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -38,6 +38,7 @@ var downloadCmd = &cobra.Command{
 		skipImageSet, _ := cmd.Flags().GetBool("skip-imageset")
 		download(folder, release, url, aiImages, additionalImages, rmStale, generateImageSet, skipImageSet)
 	},
+	Version: Version,
 }
 
 func init() {

--- a/cmd/partition.go
+++ b/cmd/partition.go
@@ -22,6 +22,7 @@ var partitionCmd = &cobra.Command{
 		size, _ := cmd.Flags().GetInt("size")
 		partition(device, size)
 	},
+	Version: Version,
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var Version = "0.0.0"
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "factory-precaching-cli",
@@ -17,6 +19,7 @@ var rootCmd = &cobra.Command{
 	Long: `factory-precaching-cli is a tool that facilitates pre-caching OpenShift artifacts
 in servers to avoid downloading them at provisioning time.
 `,
+	Version: Version,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },

--- a/hack/build-binaries.sh
+++ b/hack/build-binaries.sh
@@ -5,6 +5,14 @@ set -o pipefail
 HACKDIR=$( dirname $( readlink -f "${BASH_SOURCE[0]}" ) )
 BASEDIR="${HACKDIR}/.."
 
+# Define version string
+export GO_PACKAGE=$(go list -mod=vendor -m -f '{{ .Path }}')
+export SOURCE_GIT_BRANCH=$(git branch --show-current 2>/dev/null)
+export SOURCE_GIT_COMMIT=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null)
+export SOURCE_GIT_TREE_STATE=$(git diff --quiet >&/dev/null || echo '+dirty')
+export BUILD_DATE=$(date -u +'%Y%m%d.%H%M%S')
+export VERSION_STR="${BUILD_DATE}+${SOURCE_GIT_BRANCH}.${SOURCE_GIT_COMMIT}${SOURCE_GIT_TREE_STATE}"
+
 export GO111MODULE=on
 export GOPROXY=off
 export GOFLAGS=-mod=vendor
@@ -12,4 +20,6 @@ export GOOS=linux
 export GOARCH=amd64
 export CGO_ENABLED=0
 
-go build -v -o "${BASEDIR}/_output/factory-precaching-cli" main.go
+go build \
+    -ldflags="-X '${GO_PACKAGE}/cmd.Version=${VERSION_STR}'" \
+    -v -o "${BASEDIR}/_output/factory-precaching-cli" main.go


### PR DESCRIPTION
Added build information to the factory-precaching-cli tool to create a version string, displayed with --version. String is comprised of a build timestamp, along with the git branch and commit.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @alosadagrande 