### PR TITLE
Passes hub-version an argument to pull proper ACM and MCE operators

### DIFF
--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -18,7 +18,7 @@ mirror:
 # Example operators specification:
 #
 #  operators:
-#    - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}
+#    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
 #      full: true
 #      packages:
 #        - name: ptp-operator
@@ -34,14 +34,30 @@ mirror:
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}
       packages:
-#        - name: advanced-cluster-management
-#          channels:
-#             - name: 'release-2.6'
-#             - name: 'release-2.5'
-#        - name: multicluster-engine
-#          channels:
-#             - name: 'stable-2.1'
-#             - name: 'stable-2.0'
+        - name: advanced-cluster-management
+          channels:
+             - name: 'release-2.6'
+  {{- if eq (slice .HubVersion 0 4) "2.6."}}
+               minVersion: {{ .HubVersion }}
+               maxVersion: {{ .HubVersion }}
+  {{- end }}
+  {{- if eq (slice .HubVersion 0 4) "2.5."}}
+             - name: 'release-2.5'
+               minVersion: {{ .HubVersion }}
+               maxVersion: {{ .HubVersion }}
+  {{- end }}
+        - name: multicluster-engine
+          channels:
+             - name: 'stable-2.1'
+  {{- if eq (slice .HubVersion 0 4) "2.6."}}
+               minVersion: 2.1.{{ slice .HubVersion 4 5 }}
+               maxVersion: 2.1.{{ slice .HubVersion 4 5 }}
+  {{- end }}
+  {{- if eq (slice .HubVersion 0 4) "2.5."}}
+             - name: 'stable-2.0'
+               minVersion: 2.0.{{ slice .HubVersion 4 5 }}
+               maxVersion: 2.0.{{ slice .HubVersion 4 5 }}
+  {{- end}}        
         - name: local-storage-operator
           channels:
             - name: 'stable'
@@ -54,6 +70,17 @@ mirror:
         - name: cluster-logging
           channels:
             - name: 'stable'
+  {{- if eq .Channel "4.12" }}
+        - name: odf-lvm-operator
+        channels:
+          - name: 'stable-4.12'
+        - name: amq7-interconnect-operator
+          channels:
+            - name: '1.10.x'
+        - name: bare-metal-event-relay
+          channels:
+            - name: 'stable'
+  {{- end }}
     - catalog: registry.redhat.io/redhat/certified-operator-index:v{{ .Channel }}
       packages:
         - name: sriov-fec


### PR DESCRIPTION
This PR is intended to start discussing what operator images need to be pulled depending on the hub cluster that is going to be used to run ZTP:

* Adds a new argument called --hub-version as a string and mandatory field. The name of the arg can be discussed. The code verifies it is in the format ~ \d\.d\.\d (ex. 2.5.4)
* The template.go has changed to include a value passed as hub-version so only the version entered must be pulled down locally. However, since the last split in RHACM, now there are two operators: ACM and MCE. MCE version 2.0.x matches ACM 2.5.x, MCE version 2.1.x matches ACM 2.6.x, and it's been told it continue like that in future releases. So I assumed that.
* Another important point is that oc-mirror requires mirroring the version of the default channel even if it is not requested. That's why ACM 2.6.x and  MCE 2.1.x are always included, otherwise oc-mirror will fail. See this statement from oc-mirror gh repo:
```
WARNING: When filtering an operator package by version or channel, the default channel MUST not be filtered out. There is currently no mechanism to reset the default channel and this is required to be in the package with at least one bundle attached for the catalog to be valid.oc-mirror will error if the catalog is invalid.
```
* The template also takes into account the OCP release, since the du-profile **might** include a couple of new operators in 4.12: baremetal event operator, AMQ and probably LVMO. For 4.11 we keep the same operators since they are the approved ones.

TODO/discuss:

* There is a need to programmatically know what is the current default channel for ACM/MCE so that in future releases we do not need to modify templates.go and can be always included in case of requesting an older release of those operators.
* Since we are now including the MCE operator by including the mandatory argument hub-version, I do not think we need to include the --ai-images, it can be figured out. The official AI images are included in the MCE operator, so we just need to filter by agent, reporter, etc... and include them in the ai-images.txt. However, we should keep the --ai-images in cases where we need to override those images (dev).
* We need to document the mentioned link between ACM and MCE versions. It is the only supported way.

cc/ @donpenney @browsell @obochan-rh
Signed-off-by: Alberto Losada <alosadag@redhat.com>