### PR TITLE
Restrict golang img version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/library/golang:1.18 as builder
+FROM mirror.gcr.io/library/golang:1.18.7 as builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/library/golang:1.18 as builder
+FROM mirror.gcr.io/library/golang:1.18.7 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Currently, the 1.18 tag of mirror.gcr.io/library/golang is unavailable, since the most recent golang image update. To work around this for our image builds, this update locks the version to the most recent version currently available, 1.18.7

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @alosadagrande @browsell 