### PR TITLE
CNF-6631: Drop requirement for --ai-img options

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -26,10 +26,6 @@ import (
 var DefaultParallelization = int(float32(runtime.NumCPU()) * 0.8) // Default to 80% of available cores
 const MaxRequeues = 3
 
-// Using SHAs for ACM 2.5.1 as defaults
-const ACMDefaultAIAgentImage = "registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:482618e19dc48990bb53f46e441ce21f574c04a6e0b9ee8fe1103284e15db994"
-const ACMDefaultAIInstallerImage = "registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:e0dbc04261a5f9d946d05ea40117b6c3ab33c000ae256e062f7c3e38cdf116cc"
-
 // downloadCmd represents the download command
 var downloadCmd = &cobra.Command{
 	Use:   "download",
@@ -278,7 +274,7 @@ func contains(stringlist []string, s string) bool {
 
 func saveToImagesFile(image, imageMapping string, aiImages []string, aiImagesFile *os.File, ocpImagesFile *os.File) {
 	splittedImageMapping := strings.Split(imageMapping, ":")
-	if contains(aiImages, image) {
+	if contains(aiImages, image) || strings.HasPrefix(splittedImageMapping[0], "multicluster-engine/assisted-installer") {
 		aiImagesFile.WriteString(image + "\n")
 		if strings.Contains(splittedImageMapping[0], "assisted-installer-reporter") {
 			ocpImagesFile.WriteString(image + "\n")
@@ -347,11 +343,6 @@ func download(folder, release, url string,
 				os.Exit(1)
 			}
 		}
-	}
-
-	if len(aiImages) == 0 {
-		// No AI images specified, so use defaults
-		aiImages = append(aiImages, ACMDefaultAIAgentImage, ACMDefaultAIInstallerImage)
 	}
 
 	imagesetFile := path.Join(folder, "imageset.yaml")

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -30,7 +30,6 @@ mirror:
 #        - name: cluster-logging
 #          channels:
 #            - name: 'stable'
-{{- if .DuProfile }}
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}
       packages:
@@ -58,6 +57,7 @@ mirror:
                minVersion: 2.0.{{ slice .HubVersion 4 5 }}
                maxVersion: 2.0.{{ slice .HubVersion 4 5 }}
   {{- end}}        
+  {{- if .DuProfile }}
         - name: local-storage-operator
           channels:
             - name: 'stable'

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -33,18 +33,6 @@ mirror:
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}
       packages:
-        - name: advanced-cluster-management
-          channels:
-             - name: 'release-2.6'
-  {{- if eq (slice .HubVersion 0 4) "2.6."}}
-               minVersion: {{ .HubVersion }}
-               maxVersion: {{ .HubVersion }}
-  {{- end }}
-  {{- if eq (slice .HubVersion 0 4) "2.5."}}
-             - name: 'release-2.5'
-               minVersion: {{ .HubVersion }}
-               maxVersion: {{ .HubVersion }}
-  {{- end }}
         - name: multicluster-engine
           channels:
              - name: 'stable-2.1'
@@ -58,6 +46,18 @@ mirror:
                maxVersion: 2.0.{{ slice .HubVersion 4 5 }}
   {{- end}}        
   {{- if .DuProfile }}
+        - name: advanced-cluster-management
+          channels:
+             - name: 'release-2.6'
+  {{- if eq (slice .HubVersion 0 4) "2.6."}}
+               minVersion: {{ .HubVersion }}
+               maxVersion: {{ .HubVersion }}
+  {{- end }}
+  {{- if eq (slice .HubVersion 0 4) "2.5."}}
+             - name: 'release-2.5'
+               minVersion: {{ .HubVersion }}
+               maxVersion: {{ .HubVersion }}
+  {{- end }}
         - name: local-storage-operator
           channels:
             - name: 'stable'


### PR DESCRIPTION
Rather than using --ai-img (or hardcoded defaults) to determine images to add to ai-images.txt list, check image tags from oc-mirror query results for multicluster-engine/assisted-installer pattern.

Signed-off-by: Don Penney <dpenney@redhat.com>