### PR TITLE
OCPBUGS-5162: Replace hub-version with separate ACM and MCE opts

### DIFF
--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -37,29 +37,23 @@ mirror:
       packages:
         - name: multicluster-engine
           channels:
-             - name: 'stable-2.1'
-  {{- if eq (slice .HubVersion 0 4) "2.6."}}
-               minVersion: 2.1.{{ slice .HubVersion 4 5 }}
-               maxVersion: 2.1.{{ slice .HubVersion 4 5 }}
-  {{- end }}
-  {{- if eq (slice .HubVersion 0 4) "2.5."}}
-             - name: 'stable-2.0'
-               minVersion: 2.0.{{ slice .HubVersion 4 5 }}
-               maxVersion: 2.0.{{ slice .HubVersion 4 5 }}
-  {{- end}}        
-  {{- if .DuProfile }}
+{{- /* Because there is no versionless "stable" channel, we need to include the latest versioned channel */ -}}
+{{- if ne .MceChannel "2.1" }}
+            - name: 'stable-2.1'
+{{- end }}
+            - name: 'stable-{{.MceChannel}}'
+              minVersion: {{ .MceVersion }}
+              maxVersion: {{ .MceVersion }}
+{{- if .DuProfile }}
         - name: advanced-cluster-management
           channels:
-             - name: 'release-2.6'
-  {{- if eq (slice .HubVersion 0 4) "2.6."}}
-               minVersion: {{ .HubVersion }}
-               maxVersion: {{ .HubVersion }}
+  {{- /* Because there is no versionless "release" channel, we need to include the latest versioned channel */ -}}
+  {{- if ne .AcmChannel "2.6" }}
+            - name: 'release-2.6'
   {{- end }}
-  {{- if eq (slice .HubVersion 0 4) "2.5."}}
-             - name: 'release-2.5'
-               minVersion: {{ .HubVersion }}
-               maxVersion: {{ .HubVersion }}
-  {{- end }}
+            - name: 'release-{{ .AcmChannel }}'
+              minVersion: {{ .AcmVersion }}
+              maxVersion: {{ .AcmVersion }}
         - name: local-storage-operator
           channels:
             - name: 'stable'
@@ -74,8 +68,8 @@ mirror:
             - name: 'stable'
   {{- if eq .Channel "4.12" }}
         - name: odf-lvm-operator
-        channels:
-          - name: 'stable-4.12'
+          channels:
+            - name: 'stable-4.12'
         - name: amq7-interconnect-operator
           channels:
             - name: '1.10.x'

--- a/docs/downloading.md
+++ b/docs/downloading.md
@@ -75,15 +75,17 @@ Usage:
   factory-precaching-cli download [flags]
 
 Flags:
+      --acm-version string   Advanced Cluster Management operator version, in X.Y.Z format
   -i, --ai-img strings       Assisted Installer Image(s)
       --du-profile           Pre-cache telco 5G DU operators
   -f, --folder string        Folder to download artifacts
       --generate-imageset    Generate imageset.yaml only
   -h, --help                 help for download
-      --hub-version string   RHACM operator version in a.x.z format
+      --hub-version string   (deprecated) RHACM operator version, in X.Y.Z format
   -a, --img strings          Additional Image(s)
+      --mce-version string   MultiCluster Engine operator version, in X.Y.Z format
   -p, --parallel int         Maximum parallel downloads (default 83)
-  -r, --release string       OpenShift release version
+  -r, --release string       OpenShift release version, in X.Y.Z format
   -s, --rm-stale             Remove stale images
   -u, --rootfs-url string    rootFS URL
       --skip-imageset        Skip imageset.yaml generation
@@ -102,7 +104,7 @@ The factory-precaching-cli tool allows us to precache all the container images r
 
 ```console
 # podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools -- \
-   factory-precaching-cli download -r 4.11.5 --hub-version 2.5.4 -f /mnt \
+   factory-precaching-cli download -r 4.11.5 --acm-version 2.5.4 --mce-version 2.0.4 -f /mnt \
    --ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \
    --ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \
    --ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \
@@ -130,7 +132,8 @@ Downloaded artifact [176/176]: ocp-v4.0-art-dev@sha256_e68d705c63061c735fb00f0d2
 Summary:
 
 Release:                            4.11.5
-Hub Version:                        2.5.4
+ACM Version:                        2.5.4
+MCE Version:                        2.0.4
 Include DU Profile:                 No
 Workers:                            83
 
@@ -168,11 +171,14 @@ $ ls -l /mnt
 
 Aside from precaching the OCP release, we can also precache the day-2 operators used in telco 5G RAN. They are known as well as the telco 5G RAN distributed unit (DU) profile. They depend on the version of OCP that is going to be installed. However, you just need to add the `--du-profile` argument so that the factory-precaching-cli will do the hard work for you. 
 
-Notice that you need also to include the ACM hub version, using `--hub-version`, so that the tool figures out what containers images from RHACM and MCE operators need to pre-stage.
+Notice that you need also to include the ACM and MCE versions, using `--acm-version` and `--mce-version`, so that the tool figures out what containers images from RHACM and MCE operators need to pre-stage. Note the ACM version is only required if `--du-profile` is specified, while MCE version is always needed.
+
+Please also note the `--hub-version` option has been deprecated in favour of the separate `--acm-version` and
+`--mce-version` options, to support independent versioning.
 
 ```console
 # podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli \
-    download -r 4.11.5 --hub-version 2.5.4 -f /mnt \
+    download -r 4.11.5 --acm-version 2.5.4 --mce-version 2.0.4 -f /mnt \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \
@@ -203,7 +209,8 @@ Downloaded artifact [376/376]: hive-rhel8@sha256_609cddbaacc9f50906119104da8f532
 Summary:
 
 Release:                            4.11.5
-Hub Version:                        2.5.4
+ACM Version:                        2.5.4
+MCE Version:                        2.0.4
 Include DU Profile:                 Yes
 Workers:                            83
 
@@ -224,7 +231,7 @@ By default the factory-precaching-cli tool enables the argument `--generate-imag
 
 ```console
 # podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli \
-    download -r 4.11.5 --hub-version 2.5.4 -f /mnt \
+    download -r 4.11.5 --acm-version 2.5.4 --mce-version 2.0.4 -f /mnt \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \
@@ -241,7 +248,7 @@ Based on the options included in the call, an imageset like the following one is
 * The OCP release version and channel match the one passed to the tool.
 * Additional images are included too,
 * The operator's section includes the 5G RAN DU operators for the 4.11.z release of OpenShift: LSO, PTP, SR-IOV, Logging and the Accelerator operator.
-* The RHACM and MCE operators match the `--hub-version` version passed to the tool.
+* The RHACM and MCE operators match the `--acm-version` and `--mce-version` versions passed to the tool.
 
 
 ```yaml
@@ -338,7 +345,7 @@ Then, we need to start the downloading of the images by explicitly (--skip-image
 
 ```console
 # podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli \
-    download -r 4.11.5 --hub-version 2.5.4 -f /mnt \
+    download -r 4.11.5 --acm-version 2.5.4 --mce-version 2.0.4 -f /mnt \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \
@@ -376,7 +383,7 @@ Next, we just need to mount the host `/etc/pki` folder into the factory-precachi
 
 ```console
 # podman run -v /mnt:/mnt -v /root/.docker:/root/.docker -v /etc/pki:/etc/pki --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- \
-    factory-precaching-cli download -r 4.11.5 --hub-version 2.5.4 -f /mnt \
+    factory-precaching-cli download -r 4.11.5 --acm-version 2.5.4 --mce-version 2.0.4 -f /mnt \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \
     --ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \


### PR DESCRIPTION
Added --acm-version and --mce-version options to replace the --hub-version option, which was based on an invalid assumption that the Z component of the ACM and MCE versions matched and only the Y component differed.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @alosadagrande 