### PR TITLE
OCPBUGS-5911: Include AMQ and BMER for 4.10 and up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/library/golang:1.18.7 as builder
+FROM mirror.gcr.io/library/golang:1.18-bullseye as builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/library/golang:1.18.7 as builder
+FROM mirror.gcr.io/library/golang:1.18-bullseye as builder
 
 WORKDIR /workspace
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -55,6 +55,24 @@ func versionAtLeast(version, atleast string) bool {
 	}
 }
 
+func versionAtMost(version, atmost string) bool {
+	versionComponents := strings.Split(version, ".")
+	verX, _ := strconv.Atoi(versionComponents[0])
+	verY, _ := strconv.Atoi(versionComponents[1])
+
+	atmostComponents := strings.Split(atmost, ".")
+	atmostX, _ := strconv.Atoi(atmostComponents[0])
+	atmostY, _ := strconv.Atoi(atmostComponents[1])
+
+	if verX > atmostX {
+		return false
+	} else if verX < atmostX {
+		return true
+	} else {
+		return verY <= atmostY
+	}
+}
+
 // deprecatedHubVersionToAcmMce translates the hubVersion to acmVersion and mceVersions to provide
 // minimal backwards-compatible support for the deprecated --hub-version option, which uses an invalid
 // assumption that the Z value of the ACM and MCE Z-stream versions are the same. Because this assumption
@@ -342,7 +360,10 @@ func imageDownloaderResults(wg *sync.WaitGroup, results <-chan DownloadResult, t
 }
 
 func templatizeImageset(release, folder string, aiImages, additionalImages []string, duProfile bool, acmVersion, mceVersion string) {
-	t, err := template.New("ImageSet").Funcs(template.FuncMap{"VersionAtLeast": versionAtLeast}).Parse(imageSetTemplate)
+	t, err := template.New("ImageSet").Funcs(template.FuncMap{
+		"VersionAtLeast": versionAtLeast,
+		"VersionAtMost":  versionAtMost,
+	}).Parse(imageSetTemplate)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: unable to parse template: %v\n", err)
 		os.Exit(1)

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -66,10 +66,10 @@ mirror:
         - name: cluster-logging
           channels:
             - name: 'stable'
-  {{- if eq .Channel "4.12" }}
+  {{- if VersionAtLeast .Version "4.10" }}
         - name: odf-lvm-operator
           channels:
-            - name: 'stable-4.12'
+            - name: 'stable-{{ .Channel }}'
         - name: amq7-interconnect-operator
           channels:
             - name: '1.10.x'

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -66,16 +66,27 @@ mirror:
         - name: cluster-logging
           channels:
             - name: 'stable'
-  {{- if VersionAtLeast .Version "4.10" }}
+  {{- if VersionAtLeast .Version "4.12" }}
+        - name: lvms-operator
+          channels:
+            - name: 'stable-{{ .Channel }}'
+  {{- else if VersionAtLeast .Version "4.10" }}
         - name: odf-lvm-operator
           channels:
             - name: 'stable-{{ .Channel }}'
+  {{- end }}
+  {{- if VersionAtLeast .Version "4.10" }}
         - name: amq7-interconnect-operator
           channels:
             - name: '1.10.x'
         - name: bare-metal-event-relay
           channels:
             - name: 'stable'
+  {{- end }}
+  {{- if VersionAtMost .Version "4.10" }}
+        - name: performance-addon-operator
+          channels:
+            - name: '{{ .Channel }}'
   {{- end }}
     - catalog: registry.redhat.io/redhat/certified-operator-index:v{{ .Channel }}
       packages:


### PR DESCRIPTION
Added a template helper function to allow for conditionals in the template that check the specified release to be at least a specific Y-stream version, such as including a block if the release is 4.12 or higher. This function has been used in the template to update the inclusion of the AMQ and BMER operators for 4.10 and up, where the existing inclusion checked explicitly for 4.12 only.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @alosadagrande 