### PR TITLE
CNF-7771: Add markdown TOCs and fix markdownlint warnings

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,12 @@
+# See https://github.com/DavidAnson/markdownlint#optionsconfig
+# and https://github.com/DavidAnson/markdownlint-cli2
+
+config:
+  line-length:
+    line_length: 300
+    code_blocks: false
+
+  ul-style: consistent
+  emphasis-style: true
+  strong-style: true
+  no-space-in-emphasis: true

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,21 +1,30 @@
 # Developing in telco-ran-tools
 
+- [Developing in telco-ran-tools](#developing-in-telco-ran-tools)
+  - [Makefile targets](#makefile-targets)
+  - [Linter tests](#linter-tests)
+  - [Updates to extract-ai.sh and extract-ocp.sh](#updates-to-extract-aish-and-extract-ocpsh)
+  - [Building the image](#building-the-image)
+
 ## Makefile targets
 
 ## Linter tests
 
 As of this writing, two linters are run by the `make ci-job` command:
 
-* shellcheck
-* bashate
+- shellcheck
+- bashate
 
 These tests will be run automatically as part of the ci-job test post a pull request an update. Failures will mean your pull request
 cannot be merged. It is recommended that you run `make ci-job` regularly as part of development.
+
+Additionally, markdownlint-cli2 can be run manually using `make markdownlint`.
 
 ## Updates to extract-ai.sh and extract-ocp.sh
 
 When updating the extract-ai.sh and extract-ocp.sh scripts, you will also need to update the ignition sample files and
 the corresponding documentation. This can be done by running:
+
 ```bash
 make update-resources
 ```
@@ -23,11 +32,13 @@ make update-resources
 ## Building the image
 
 The Makefile has variables to support building images for development:
-* REPOOWNER - the registry in quay.io for the image (defaults to openshift-kni)
-* IMAGENAME - the image name (defaults to telco-ran-tools)
-* IMAGETAG - the image tag (defaults to latest)
+
+- REPOOWNER - the registry in quay.io for the image (defaults to openshift-kni)
+- IMAGENAME - the image name (defaults to telco-ran-tools)
+- IMAGETAG - the image tag (defaults to latest)
 
 To build the image, run the `image` make target, or run the `push` make target to build and push the image:
+
 ```bash
 make REPOOWNER=${USER} push
 ```

--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,23 @@ test-unit-cmd:
 .PHONY: test-e2e
 test-e2e: binaries
 	ginkgo test/e2e
+
+PULL_BASE_SHA ?= origin/main # Allow the template check base ref to be overridden
+
+.PHONY: markdownlint-image
+markdownlint-image:  ## Build local container markdownlint-image
+	$(RUNTIME) image build -f ./hack/Dockerfile.markdownlint --tag $(IMAGENAME)-markdownlint:latest
+
+.PHONY: markdownlint-image-clean
+markdownlint-image-clean:  ## Remove locally cached markdownlint-image
+	$(RUNTIME) image rm $(IMAGENAME)-markdownlint:latest
+
+markdownlint: markdownlint-image  ## run the markdown linter
+	$(RUNTIME) run \
+		--rm=true \
+		--env RUN_LOCAL=true \
+		--env VALIDATE_MARKDOWN=true \
+		--env PULL_BASE_SHA=$(PULL_BASE_SHA) \
+		-v $$(pwd):/workdir:Z \
+		$(IMAGENAME)-markdownlint:latest
+

--- a/README.md
+++ b/README.md
@@ -1,37 +1,57 @@
-# telco-ran-tools
+# telco-ran-tools #
 
 This repository holds tools used by the Telco RAN team.
 
-## factory-precaching-cli
+- [telco-ran-tools](#telco-ran-tools)
+  - [factory-precaching-cli](#factory-precaching-cli)
+    - [Motivation](#motivation)
+    - [Description](#description)
+    - [Building](#building)
+    - [Usage](#usage)
+    - [Display help](#display-help)
 
-### Motivation 
-In environments with limited bandwidth and using the RH GitOps ZTP solution to deploy a large number of clusters for RAN workloads, it might be desirable to avoid the use of the network for downloading all the artifacts required for bootstrapping and installing OCP.  Remember that the bandwidth to remote DU SNO sites is limited resulting in long deployment times with the existing ZTP solution. In order to address the bandwidth limitations, a factory pre-staging solution is required to eliminate the download of artifacts at the remote site.
+## factory-precaching-cli ##
 
-As artifacts, we refer both to container images and images such as the rootFS which currently can only be pulled from an HTTP/HTTPS server when booting from the small ISO. One can think of using the RHCOS live full ISO to avoid downloading the rootFS image, but it is discouraged because there are BMCs that do not accept the use of ISO files with such large sizes. 
+### Motivation ###
 
-This work is targeting hardware where one disk, actually the installation disk, is only available. In this case, when installing OCP via ZTP/Assisted Installer using the small ISO, we need to:
+In environments with limited bandwidth and using the RH GitOps ZTP solution to deploy a large number of clusters for RAN
+workloads, it might be desirable to avoid the use of the network for downloading all the artifacts required for
+bootstrapping and installing OCP.  Remember that the bandwidth to remote DU SNO sites is limited resulting in long
+deployment times with the existing ZTP solution. In order to address the bandwidth limitations, a factory pre-staging
+solution is required to eliminate the download of artifacts at the remote site.
 
-* Allow copying the rootFS file at boot time from a local disk path instead of using the network. Currently, only HTTP/HTTPS location is allowed via the image-url flag. 
-* Pre-stage OCP release images in a partition of the installation disk which is saved during OCP installation.
-* Pre-stage day-2 operators (specifically telco operators) in the same partition during OCP configuration. In particular when applying the DU profile.
+As artifacts, we refer both to container images and images such as the rootFS which currently can only be pulled from an
+HTTP/HTTPS server when booting from the small ISO. One can think of using the RHCOS live full ISO to avoid downloading
+the rootFS image, but it is discouraged because there are BMCs that do not accept the use of ISO files with such large
+sizes.
+
+This work is targeting hardware where one disk, actually the installation disk, is only available. In this case, when
+installing OCP via ZTP/Assisted Installer using the small ISO, we need to:
+
+- Allow copying the rootFS file at boot time from a local disk path instead of using the network. Currently, only HTTP/HTTPS location is allowed via the image-url flag.
+- Pre-stage OCP release images in a partition of the installation disk which is saved during OCP installation.
+- Pre-stage day-2 operators (specifically telco operators) in the same partition during OCP configuration. In particular when applying the DU profile.
 
 > :warning: The factory-cli tool can target hardware with more than one disk installed as well, however as stated this is not the main objective.
 
-### Description
-The factory-precaching-cli tool facilitates the pre-staging of servers before they are shipped to the site for later ZTP provisioning. 
+### Description ###
 
-The tool does the following: 
-* Creates a partition from the installation disk labelled as data.
-* Formats the disk (xfs).
-* Creates a GPT data partition at the end of the disk. Size is configurable by the tool.
-* Copies the container images required to install OCP.
-* Copies the container images required by ZTP to install OCP.
-* If requested, day-2 operators are copied to the partition too.
-* Downloads the RHCOS rootfs image required by the minimal ISO to boot.
+The factory-precaching-cli tool facilitates the pre-staging of servers before they are shipped to the site for later ZTP provisioning.
 
-### Building
-```
-[ricky@localhost telco-ran-tools]$ make build
+The tool does the following:
+
+- Creates a partition from the installation disk labelled as data.
+- Formats the disk (xfs).
+- Creates a GPT data partition at the end of the disk. Size is configurable by the tool.
+- Copies the container images required to install OCP.
+- Copies the container images required by ZTP to install OCP.
+- If requested, day-2 operators are copied to the partition too.
+- Downloads the RHCOS rootfs image required by the minimal ISO to boot.
+
+### Building ###
+
+``` console
+$ make build
 mkdir -p _output || :
 go mod tidy && go mod vendor
 Running go fmt
@@ -45,18 +65,19 @@ command-line-arguments
 
 The binary can be found in _output/factory-precaching-cli
 
-### Usage
+### Usage ###
 
 Detailed information and examples of each stage can be found in the following links:
 
-* [Booting RHCOS live](docs/liveos.md)
-* [Partitioning](docs/partitioning.md)
-* [Downloading the artifacts](docs/downloading.md)
-* [ZTP configuration for precaching](docs/ztp-precaching.md)
+- [Booting RHCOS live](docs/liveos.md)
+- [Partitioning](docs/partitioning.md)
+- [Downloading the artifacts](docs/downloading.md)
+- [ZTP configuration for precaching](docs/ztp-precaching.md)
 
-# Display help
-```
-[ricky@localhost telco-ran-tools]$ ./factory-precaching-cli --help
+### Display help ###
+
+``` console
+$ ./factory-precaching-cli --help
 factory-precaching-cli is a tool that facilitates pre-caching OpenShift artifacts
 in servers to avoid downloading them at provisioning time.
 

--- a/docs/partitioning.md
+++ b/docs/partitioning.md
@@ -1,16 +1,31 @@
 # Factory-cli: Partitioning #
 
+- [Factory-cli: Partitioning](#factory-cli-partitioning)
+  - [Background](#background)
+  - [Pre-requisites](#pre-requisites)
+  - [Partitioning and formatting](#partitioning-and-formatting)
+    - [Verify the disk is cleared](#verify-the-disk-is-cleared)
+    - [Create the partition](#create-the-partition)
+    - [Mount the partition](#mount-the-partition)
+
 ## Background ##
 
-As mentioned, the idea is to focus on those servers where only one disk is available and no external disk drive is possible to be attached. Notice that assisted installer, which is part of the ZTP flow, leverages the coreos-installer utility to write RHCOS to disk. Therefore, if we boot from a pre-installed RHCOS on the device, the utility will complain because the device is in use and cannot finish the process of writing. Then, the only way we have to run the full pre-caching process is by booting from a live ISO and using the factory-cli tool from a container image to partition and pre-cache all the artifacts required.
+As mentioned, the idea is to focus on those servers where only one disk is available and no external disk drive is
+possible to be attached. Notice that assisted installer, which is part of the ZTP flow, leverages the coreos-installer
+utility to write RHCOS to disk. Therefore, if we boot from a pre-installed RHCOS on the device, the utility will
+complain because the device is in use and cannot finish the process of writing. Then, the only way we have to run the
+full pre-caching process is by booting from a live ISO and using the factory-cli tool from a container image to
+partition and pre-cache all the artifacts required.
 
 > :warning: RHCOS requires the disk to not be in use when is about to be written by an RHCOS image. Reinstalling onto the current boot disk is an unusual requirement, and the coreos-installer utility wasn't designed for it.
 
-## Pre-requisites
+## Pre-requisites ##
 
-As a requirement before starting the partitioning process with the factory-cli, we need the disk to be not partitioned. If it is partitioned we can boot from an [RHCOS live ISO](https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/latest/rhcos-4.11.9-x86_64-live.x86_64.iso), delete the partition and wipe the full device. See the process below for deleting a partition of the nvme0n1 disk:
+As a requirement before starting the partitioning process with the factory-cli, we need the disk to be not partitioned.
+If it is partitioned we can boot from an [RHCOS live ISO](https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/latest/rhcos-4.11.9-x86_64-live.x86_64.iso),
+delete the partition and wipe the full device. See the process below for deleting a partition of the nvme0n1 disk:
 
-```
+``` console
 [root@snonode /]# lsblk
 NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
 loop0         7:0    0  93.8G  0 loop /run/ephemeral
@@ -51,9 +66,11 @@ nvme0n1 259:1    0   1.5T  0 disk
 
 > :exclamation: It is recommended to use NVME disk in your servers.
 
-A second prerequisite is being able to pull the quay.io/openshift-kni/telco-ran-tools:latest that will be used to run the factory-cli tool. The image is publicly available in quay.io but if you are in a disconnected environment or have a corporate private registry, you will need to copy the image there so it can be downloaded to the server.
+A second prerequisite is being able to pull the quay.io/openshift-kni/telco-ran-tools:latest that will be used to run
+the factory-cli tool. The image is publicly available in quay.io but if you are in a disconnected environment or have a
+corporate private registry, you will need to copy the image there so it can be downloaded to the server.
 
-```
+``` console
 [root@snonode /]# podman pull quay.io/openshift-kni/telco-ran-tools:latest
 Trying to pull quay.io/openshift-kni/telco-ran-tools:latest...
 Getting image source signatures
@@ -71,25 +88,24 @@ Storing signatures
 4b99f87ac7872f8b6cdfea50ec0aed44d5145a33b171e22c33b866ce15759c72
 ```
 
-```
+``` console
 [root@snonode /]# podman run quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli -v
 factory-precaching-cli version 20221018.120852+main.feecf17
 ```
 
 Finally, we need to be sure that the disk is big enough to install OpenShift and also precache all the container images required: OCP release and day2 operators. Based on our experience:
 
-* If you are going to precache only OCP release artifacts a 100GB partition is enough
-* If you want to precache both OCP release artifacts and the DU profile day2 operators, around 250GB of disk space is required.
-* Lastly, take into account that OCP installation requires a minimum 120GB to be installed. So, you need to add this size to precached partition.
+- If you are going to precache only OCP release artifacts a 100GB partition is enough
+- If you want to precache both OCP release artifacts and the DU profile day2 operators, around 250GB of disk space is required.
+- Lastly, take into account that OCP installation requires a minimum 120GB to be installed. So, you need to add this size to precached partition.
 
 > :warning: The factory-cli tool allows you to precache any other container image you will need for your environment. Then, make sure that the size of those extra images is taken into account in the sizing exercise.
 
-
-## Partitioning and formatting
+## Partitioning and formatting ##
 
 Let's start with the partitioning, for that we will use the partition argument from the factory-cli. See here all the options we have:
 
-```
+``` console
 [root@snonode /]# podman run quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli partition --help
 Partitions and formats a disk
 
@@ -103,11 +119,11 @@ Flags:
   -v, --version         version for partition
 ```
 
-### Verify the disk is cleared
+### Verify the disk is cleared ###
 
 As mentioned in the previous section, we need our disk to be empty. Please make sure it is before starting the process. This is an example of a nvme0n1 device with no partitions:
 
-```
+``` console
 [root@snonode /]# lsblk
 NAME    MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
 loop0     7:0    0  93.8G  0 loop /run/ephemeral
@@ -118,23 +134,27 @@ nvme0n1 259:1    0   1.5T  0 disk
 
 Also, it is suggested to erase filesystem, raid or partition-table signatures from the device:
 
-```
+``` console
 [root@snonode /]# wipefs -a /dev/nvme0n1
 /dev/nvme0n1: 8 bytes were erased at offset 0x00000200 (gpt): 45 46 49 20 50 41 52 54
 /dev/nvme0n1: 8 bytes were erased at offset 0x1749a955e00 (gpt): 45 46 49 20 50 41 52 54
 /dev/nvme0n1: 2 bytes were erased at offset 0x000001fe (PMBR): 55 aa
 ```
+
 > :warning: The tool will fail if the disk is not empty, as it uses the partition number 1 of the device for precaching the artifacts.
 
-### Create the partition
+### Create the partition ###
 
 Now that we have a device ready, we are going to create a single partition and a GPT partition table. This partition is going to be automatically labeled as “data” and created at the end of the device otherwise the partition will be overridden by the coreos-installer.
 
-> :exclamation: The coreos-installer requires the partition to be created at the end of the device and to be labeled as "data". Both requirements are necessary to save the partition when writing the RHCOS image to disk.
+> :exclamation: The coreos-installer requires the partition to be created at the end of the device and to be labeled as
+  "data". Both requirements are necessary to save the partition when writing the RHCOS image to disk.
 
-Notice that the container must run as privileged since we are formatting host devices. Also, mount the /dev folder so that the process can be executed inside the container. Finally, notice that the size of the partition is 250 GB since we expect to precache also the day-2 operators required for the DU profile.
+Notice that the container must run as privileged since we are formatting host devices. Also, mount the /dev folder so
+that the process can be executed inside the container. Finally, notice that the size of the partition is 250 GB since we
+expect to precache also the day-2 operators required for the DU profile.
 
-```
+``` console
 [root@snonode /]# podman run -v /dev:/dev --privileged -it --rm  quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli partition -d /dev/nvme0n1 -s 250
 Partition /dev/nvme0n1p1 is being formatted
 
@@ -149,11 +169,11 @@ nvme0n1     259:1    0   1.5T  0 disk
 
 In order to verify the proper status of the partition we can query using the gdisk tool included with RHCOS. See that:
 
-* The device now has a GPT partition table 
-* The partition is actually using the latest sectors of the device.
-* The partition has been correctly labeled as 'data'
+- The device now has a GPT partition table
+- The partition is actually using the latest sectors of the device.
+- The partition has been correctly labeled as 'data'
 
-```
+``` console
 [root@snonode /]# gdisk -l /dev/nvme0n1
 GPT fdisk (gdisk) version 1.0.3
 
@@ -178,16 +198,15 @@ Number  Start (sector)    End (sector)  Size       Code  Name
    1      2601338880      3125627534   250.0 GiB   8300  data
 ```
 
+### Mount the partition ###
 
-### Mount the partition
-
-Now, that we have verified the partition was created as expected. We can mount the device into /mnt. 
+Now, that we have verified the partition was created as expected. We can mount the device into /mnt.
 
 > :warning: It is highly suggested to mount the device into /mnt since the mounting point is taken into account during ZTP preparation stage.
 
-Notice that the partition is also formatted as xfs. 
+Notice that the partition is also formatted as xfs.
 
-```
+``` console
 [root@snonode /]# lsblk -f /dev/nvme0n1
 NAME        FSTYPE LABEL UUID                                 MOUNTPOINT
 nvme0n1                                                       
@@ -196,7 +215,7 @@ nvme0n1
 
 Then execute the mount in the terminal, there is no need to add the mount point in the /etc/fstab since we are running a live ISO.
 
-```
+``` console
 [root@snonode /]# mount /dev/nvme0n1p1 /mnt/
 
 [root@snonode /]# lsblk

--- a/docs/ztp-precaching.md
+++ b/docs/ztp-precaching.md
@@ -1,31 +1,30 @@
 # Factory-cli: Zero Touch Provisioning configuration
 
-<!-- vscode-markdown-toc -->
+- [Factory-cli: Zero Touch Provisioning configuration](#factory-cli-zero-touch-provisioning-configuration)
+  - [1. Zero Touch Provisioning (ZTP)](#1-zero-touch-provisioning-ztp)
+  - [2. ZTP workflow](#2-ztp-workflow)
+  - [3. Pre-requisites](#3-pre-requisites)
+  - [4. Preparing the siteconfig](#4-preparing-the-siteconfig)
+    - [4.1. clusters.ignitionConfigOverride](#41-clustersignitionconfigoverride)
+    - [4.2. nodes.installerArgs](#42-nodesinstallerargs)
+    - [4.3. nodes.ignitionConfigOverride](#43-nodesignitionconfigoverride)
+  - [5. Start ZTP](#5-start-ztp)
 
-* 1. [Zero Touch Provisioning (ZTP)](#ZeroTouchProvisioningZTP)
-* 2. [ZTP workflow](#ZTPworkflow)
-* 3. [Pre-requisites](#Pre-requisites)
-* 4. [Preparing the siteconfig](#Preparingthesiteconfig)
-	* 4.1. [clusters.ignitionConfigOverride](#clusters.ignitionConfigOverride)
-	* 4.2. [nodes.installerArgs](#nodes.installerArgs)
-	* 4.3. [nodes.ignitionConfigOverride](#nodes.ignitionConfigOverride)
-* 5. [Start ZTP](#StartZTP)
+>:exclamation: The factory-cli tool permits to download a rootfs image to the local partition. Therefore, when booting
+ the discovery ISO we can use a lightweight image and pull the rootfs from a local partition or from a local HTTPd
+ server. Currently ZTP does not allow a declarative and automated way to load the rootfs image from a local partition.
 
-<!-- vscode-markdown-toc-config
-	numbering=true
-	autoSave=true
-	/vscode-markdown-toc-config -->
-<!-- /vscode-markdown-toc -->
-
->:exclamation: The factory-cli tool permits to download a rootfs image to the local partition. Therefore, when booting the discovery ISO we can use a lightweight image and pull the rootfs from a local partition or from a local HTTPd server. Currently ZTP does not allow a declarative and automated way to load the rootfs image from a local partition.
-
-##  1. <a name='ZeroTouchProvisioningZTP'></a>Zero Touch Provisioning (ZTP)
+## 1. Zero Touch Provisioning (ZTP)
 
 Edge computing presents extraordinary challenges with managing hundreds to tens of thousands of clusters in hundreds of thousands of locations. These challenges require fully-automated management solutions with, as closely as possible, zero human interaction.
 
 *Zero touch provisioning (ZTP)* allows you to provision new edge sites with declarative configurations of bare-metal equipment at remote sites following a GitOps deployment set of practices. All configurations are declarative in nature.
 
-ZTP is a project to deploy and deliver OpenShift 4 in a hub-and-spoke architecture (in a relation of 1-N), where a single hub cluster manages many spoke clusters. The hub and the spokes will be based on OpenShift 4 but with the difference that the hub cluster will manage, deploy and control the lifecycle of the spokes using Red Hat Advanced Cluster Management (RHACM). So, hub clusters running RHACM apply radio access network (RAN) policies from predefined custom resources (CRs) and provision and deploy the spoke clusters using multiple products. 
+ZTP is a project to deploy and deliver OpenShift 4 in a hub-and-spoke architecture (in a relation of 1-N), where a
+single hub cluster manages many spoke clusters. The hub and the spokes will be based on OpenShift 4 but with the
+difference that the hub cluster will manage, deploy and control the lifecycle of the spokes using Red Hat Advanced
+Cluster Management (RHACM). So, hub clusters running RHACM apply radio access network (RAN) policies from predefined
+custom resources (CRs) and provision and deploy the spoke clusters using multiple products.
 
 >:exclamation: ZTP can have two scenarios, connected and disconnected, whether the OpenShift Container Platform Worker nodes can directly access the internet or not. In telco deployments, the disconnected scenario is the most common.
 
@@ -33,23 +32,39 @@ ZTP provides support for deploying single node clusters, three-node clusters, an
 
 ![ZTP framework](images/ztp_edge_framework.png "ZTP framework")
 
-##  2. <a name='ZTPworkflow'></a>ZTP workflow
+## 2. ZTP workflow
 
-Zero Touch Provisioning (ZTP) leverages multiple products or components to deploy OpenShift Container Platform clusters using a GitOps approach. While the workflow starts when the site is connected to the network and ends with the CNF workload deployed and running on the site nodes, it can be logically divided into two different stages: provisioning of the SNO and applying the desired configuration, which in our case is applying the validated RAN DU profile.
+Zero Touch Provisioning (ZTP) leverages multiple products or components to deploy OpenShift Container Platform clusters
+using a GitOps approach. While the workflow starts when the site is connected to the network and ends with the CNF
+workload deployed and running on the site nodes, it can be logically divided into two different stages: provisioning of
+the SNO and applying the desired configuration, which in our case is applying the validated RAN DU profile.
 
 > :warning: The workflow does not need any intervention, so ZTP automatically will configure the SNO once it is provisioned. However, two stages are clearly differentiated.
 
-The workflow is officially started by creating declarative configurations for the provisioning of your OpenShift clusters. This manifest is described in a custom resource called `siteConfig`. See that in a disconnected environment, there is a need for a container registry which has been configured to deliver the required OpenShift container images required for the installation. This task can be achieved by using [oc-mirror])https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-disconnected.html).
+The workflow is officially started by creating declarative configurations for the provisioning of your OpenShift
+clusters. This manifest is described in a custom resource called `siteConfig`. See that in a disconnected environment,
+there is a need for a container registry which has been configured to deliver the required OpenShift container images
+required for the installation. This task can be achieved by using
+[oc-mirror](https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-disconnected.html).
 
->:exclamation: The factory-cli-tool tries to limit the usage of a container registry to pull down the required images. Currently, a registry is still needed since a couple of components require checking the availability of certain images to continue with the installation. The end goal is avoiding this requirement.
+>:exclamation: The factory-cli-tool tries to limit the usage of a container registry to pull down the required images.
+ Currently, a registry is still needed since a couple of components require checking the availability of certain images
+ to continue with the installation. The end goal is avoiding this requirement.
 
-Depending on your specific environment, you might need a couple of extra services such as DHCP, DNS, NTP or HTTP. The latest will be needed for downloading the RHCOS live ISO and the rootfs image locally instead of the default [OpenShift mirror webpage](http://mirror.openshift.com.)
+Depending on your specific environment, you might need a couple of extra services such as DHCP, DNS, NTP or HTTP. The
+latest will be needed for downloading the RHCOS live ISO and the rootfs image locally instead of the default [OpenShift mirror webpage](http://mirror.openshift.com.)
 
 Once the configuration is created you can push it to the Git repo where Argo CD is continuously looking to pull the new content:
 
 ![ZTP workflow 0](images/ztp_workflow_0.png "ZTP workflow 0")
 
-Argo CD pulls the siteConfig and uses a specific kustomize plugin called [siteconfig-generator](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/siteconfig-generator-kustomize-plugin) to transform it into custom resources that are understood by the hub cluster (RHACM/MCE). A siteConfig contains all the necessary information to provision your node or nodes. Basically, it will create ISO images with the defined configuration that are delivered to the edge nodes to begin the installation process. The images are used to repeatedly provision large numbers of nodes efficiently and quickly, allowing you to keep up with requirements from the field for far-edge nodes. 
+Argo CD pulls the siteConfig and uses a specific kustomize plugin called
+[siteconfig-generator](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/siteconfig-generator-kustomize-plugin)
+to transform it into custom resources that are understood by the hub cluster (RHACM/MCE). A siteConfig contains all the
+necessary information to provision your node or nodes. Basically, it will create ISO images with the defined
+configuration that are delivered to the edge nodes to begin the installation process. The images are used to repeatedly
+provision large numbers of nodes efficiently and quickly, allowing you to keep up with requirements from the field for
+far-edge nodes.
 
 > :warning: On telco use cases, clusters are mainly running on bare-metal hosts. Therefore the produced ISO images are mounted using remote virtual media features of the baseboard management controller (BMC).
 
@@ -57,32 +72,48 @@ In the picture, these resulting manifests are called Cluster Installation CRs. F
 
 ![ZTP workflow 1](images/ztp_workflow_1.png "ZTP workflow 1")
 
-The provisioning process includes installing the host operating system (RHCOS) on a blank server and deploying OpenShift Container Platform. This stage is managed mainly by a ZTP component called the Infrastructure Operator
+The provisioning process includes installing the host operating system (RHCOS) on a blank server and deploying OpenShift
+Container Platform. This stage is managed mainly by a ZTP component called the Infrastructure Operator
 
 > :exclamation: Notice, in the picture, how ZTP allows us to provision clusters at scale.
 
 ![ZTP workflow 2](images/ztp_workflow_2.png "ZTP workflow 2")
 
-Once the clusters are provisioned, the day-2 configuration defined in multiple `PolicyGenTemplate` (PGTs) custom resources will be automatically applied. `PolicyGenTemplate` custom resource is understood by the ZTP using a specific kustomize plugin called [policy-generator](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/policygenerator-kustomize-plugin). In telco RAN DU nodes, this configuration includes the installation of the common telco operators, a common configuration for RAN and specific configuration (SR-IOV or performance settings) for each site since it is very dependant on the hardware.
+Once the clusters are provisioned, the day-2 configuration defined in multiple `PolicyGenTemplate` (PGTs) custom
+resources will be automatically applied. `PolicyGenTemplate` custom resource is understood by the ZTP using a specific
+kustomize plugin called [policy-generator](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/policygenerator-kustomize-plugin).
+In telco RAN DU nodes, this configuration includes the installation of the common telco operators, a common
+configuration for RAN and specific configuration (SR-IOV or performance settings) for each site since it is very
+dependant on the hardware.
 
 ![ZTP workflow 3](images/ztp_workflow_3.png "ZTP workflow 3")
 
 Notice that if, later on, you want to apply a new configuration or replace an existing configuration you must use a new `policyGenTemplate` to do that.
 
+## 3. Pre-requisites
 
-##  3. <a name='Pre-requisites'></a>Pre-requisites
+- The [partitioning stage](./partitioning.md) was already executed successfully.
+- The [downloading stage](./downloading.md) is completed, so all dependent artifacts are already stored on the disk partition.
+- The bare metal server is powered off.
 
-* The [partitioning stage](./partitioning.md) was already executed successfully.
-* The [downloading stage](./downloading.md) is completed, so all dependent artifacts are already stored on the disk partition.
-* The bare metal server is powered off.
+## 4. Preparing the siteconfig
 
-##  4. <a name='Preparingthesiteconfig'></a>Preparing the siteconfig
+As mentioned, a `siteConfig` manifest defines in a declarative manner how an OpenShift target cluster is going to be
+installed and configured. Below it is an example of a valid siteConfig, however, unlike the regular ZTP provisioning
+workflow 3 extra fields need to be included:
 
-As mentioned, a `siteConfig` manifest defines in a declarative manner how an OpenShift target cluster is going to be installed and configured. Below it is an example of a valid siteConfig, however, unlike the regular ZTP provisioning workflow 3 extra fields need to be included:
-
-* **clusters.ignitionConfigOverride**. This field adds an extra configuration in ignition format during the ZTP discovery stage. Basically, it includes a couple of systemd services in the ISO that it is mounted using virtual media. This way, those scripts are part of the RHCOS discovery live ISO and can be used at that point to load the Assisted Installer images.
-* **nodes.installerArgs**. This field allows us to configure the way coreos-installer utility writes the RHCOS live ISO to disk. In this case, we need to indicate to save the disk partition labeled as 'data'. The artifacts saved there will be needed during the OCP installation stage.
-* **nodes.ignitionConfigOverride**. This field adds similar functionality as the clusters.ignitionConfigOverride, but in the OCP installation stage. Notice that once the RHCOS is written to disk, the extra configuration included in the ZTP discovery ISO is not there anymore. It was in memory since we were running a live OS during the discovery stage. This field allows the addtion of extra configuration in ignition format to the coreos-installer binary, which is in charge of writing the RHCOS live OS to disk.
+- **clusters.ignitionConfigOverride**. This field adds an extra configuration in ignition format during the ZTP
+  discovery stage. Basically, it includes a couple of systemd services in the ISO that it is mounted using virtual
+  media. This way, those scripts are part of the RHCOS discovery live ISO and can be used at that point to load the
+  Assisted Installer images.
+- **nodes.installerArgs**. This field allows us to configure the way coreos-installer utility writes the RHCOS live ISO
+  to disk. In this case, we need to indicate to save the disk partition labeled as 'data'. The artifacts saved there
+  will be needed during the OCP installation stage.
+- **nodes.ignitionConfigOverride**. This field adds similar functionality as the clusters.ignitionConfigOverride, but in
+  the OCP installation stage. Notice that once the RHCOS is written to disk, the extra configuration included in the ZTP
+  discovery ISO is not there anymore. It was in memory since we were running a live OS during the discovery stage. This
+  field allows the addtion of extra configuration in ignition format to the coreos-installer binary, which is in charge of
+  writing the RHCOS live OS to disk.
 
 > :exclamation: You can just copy and paste the three fields described above in your siteConfig. A detailed explanation of each one is included in the following sections.
 
@@ -147,17 +178,26 @@ spec:
               macAddress: "e4:43:4b:bd:90:46"
 ```
 
-###  4.1. <a name='clusters.ignitionConfigOverride'></a>clusters.ignitionConfigOverride
+### 4.1. clusters.ignitionConfigOverride
 
 Showing the content of the field in a prettier and cleaner way will help us to understand much better what is actually doing the ignition configuration:
 
-* There are two systemd units (var-mnt.mount nad precache-images.services). The precache-images.service depends on the disk partition to be mounted in /var/mnt by the var-mnt unit. The precache-images service basically calls a script called `extract-ai.sh`. Notice that the precache-images must be executed before the `agent.service`, so it means that extracting the Assisted Installer (ai) images is done before the discovery stage starts.
-* The `extract-ai.sh` script basically uncompresses and loads the images required in this stage from the disk partition to the local container storage. Once done, images can be used locally instead of pulled down from a registry. The decoded script can be found [here](./resources/extract-ai.sh)
-* The `agent-fix-bz1964591` is currently a workaround for an issue with Assisted Installer. Essentially, Assisted Installer removes some container images if they are local, forcing them to be downloaded from the registry. In our scenario, we want to avoid that since we just loaded them into the local container storage. The decoded script can be found [here](./resources/agent-fix-bz1964591)
+- There are two systemd units (var-mnt.mount nad precache-images.services). The precache-images.service depends on the
+  disk partition to be mounted in /var/mnt by the var-mnt unit. The precache-images service basically calls a script
+  called `extract-ai.sh`. Notice that the precache-images must be executed before the `agent.service`, so it means that
+  extracting the Assisted Installer (ai) images is done before the discovery stage starts.
+- The `extract-ai.sh` script basically uncompresses and loads the images required in this stage from the disk partition
+  to the local container storage. Once done, images can be used locally instead of pulled down from a registry. The
+  decoded script can be found [here](./resources/extract-ai.sh)
+- The `agent-fix-bz1964591` is currently a workaround for an issue with Assisted Installer. Essentially, Assisted
+  Installer removes some container images if they are local, forcing them to be downloaded from the registry. In our
+  scenario, we want to avoid that since we just loaded them into the local container storage. The decoded script can be
+  found [here](./resources/agent-fix-bz1964591)
 
-> :exclamation Sometimes you could need to modify the mentioned scripts or include a new ones. In such cases you can do so by adding them into the [discovery-beauty ignition template](./resources/discovery-beauty.ign). Finally, include the modified ignition file into the siteConfig manifest in the expected format.
+> :exclamation Sometimes you could need to modify the mentioned scripts or include a new ones. In such cases you can do
+  so by adding them into the [discovery-beauty ignition template](./resources/discovery-beauty.ign). Finally, include
+  the modified ignition file into the siteConfig manifest in the expected format.
 
- 
 ``` { .json title=discovery-beauty.ign }
 {
   "ignition": {
@@ -201,17 +241,20 @@ Showing the content of the field in a prettier and cleaner way will help us to u
 }
 ```
 
-###  4.2. <a name='nodes.installerArgs'></a>nodes.installerArgs
+### 4.2. nodes.installerArgs
 
-This field, as mentioned, permits us to save the disk partition where all the container images were stored. Those extra parameters are passed directly to the `coreos-installer` binary who is in charge of writing the live RHCOS to disk. Then, on the next boot, the OS is executed from the disk. Notice that we previously named the [partition](./partitioning.md#create-the-partition) as data.
+This field, as mentioned, permits us to save the disk partition where all the container images were stored. Those extra
+parameters are passed directly to the `coreos-installer` binary who is in charge of writing the live RHCOS to disk.
+Then, on the next boot, the OS is executed from the disk. Notice that we previously named the
+[partition](./partitioning.md#create-the-partition) as data.
 
-```
+```console
 installerArgs: '["--save-partlabel", "data"]'
 ```
 
 Several extra options can be passed to the coreos-installer utility. Here below, you can see the most interesting ones:
 
-```
+```console
 # coreos-installer install --help
 coreos-installer-install 0.12.0
 Install Fedora CoreOS or RHEL CoreOS
@@ -247,17 +290,25 @@ ARGS:
             Destination device
 ```
 
-###  4.3. <a name='nodes.ignitionConfigOverride'></a>nodes.ignitionConfigOverride
+### 4.3. nodes.ignitionConfigOverride
 
-The purpose of this field is very similar to [clusters.ignitionConfigOverride](./ztp-config.md#clustersignitionconfigoverride). Unlike the previous ignitionOverride, we are in the OCP installation stage. This means that we need to extract and load the OCP images that are needed to install the cluster. Remember that in the discovery stage we are only taking care of the container images required for discovery. 
+The purpose of this field is very similar to [clusters.ignitionConfigOverride](./ztp-config.md#clustersignitionconfigoverride). Unlike the previous ignitionOverride,
+we are in the OCP installation stage. This means that we need to extract and load the OCP images that are needed to
+install the cluster. Remember that in the discovery stage we are only taking care of the container images required for
+discovery.
 
-> :warning: The number of container images extracted and loaded is way bigger than in the discovery stage. So, depending on the OCP release and whether it was requested to install the telco operators, the time it takes will vary. 
+> :warning: The number of container images extracted and loaded is way bigger than in the discovery stage. So, depending on the OCP release and whether it was requested to install the telco operators, the time it takes will vary.
 
-* There are two systemd units (var-mnt.mount and precache-ocp.services). The precache-ocp.service depends on the disk partition to be mounted in /var/mnt by the var-mnt unit. The precache-ocp service basically calls a script called `extract-ocp.sh`. Notice that the precache-ocp must be executed before the `machine-config-daemon-pull.service` and `nodeip-configuration.service`, so it means that extracting the images is done before the OCP installation starts.
-* The `extract-ocp.sh` script basically uncompresses and loads the images required in this stage from the disk partition to the local container storage. Fundamentally there are OCP release images and operators if they were requested to be installed. Once done, images can be used locally instead of pulled down from a registry. The decoded script can be found [here](./resources/extract-ocp.sh)
+- There are two systemd units (var-mnt.mount and precache-ocp.services). The precache-ocp.service depends on the disk
+  partition to be mounted in /var/mnt by the var-mnt unit. The precache-ocp service basically calls a script called
+  `extract-ocp.sh`. Notice that the precache-ocp must be executed before the `machine-config-daemon-pull.service` and
+  `nodeip-configuration.service`, so it means that extracting the images is done before the OCP installation starts.
+- The `extract-ocp.sh` script basically uncompresses and loads the images required in this stage from the disk partition
+  to the local container storage. Fundamentally there are OCP release images and operators if they were requested to be
+  installed. Once done, images can be used locally instead of pulled down from a registry. The decoded script can be found
+  [here](./resources/extract-ocp.sh)
 
 > :exclamation Sometimes you could need to modify the mentioned scripts or include a new ones. In such cases you can do so by adding them into the [boot-beauty ignition template](./resources/boot-beauty.ign). Finally, include the modified ignition file into the siteConfig manifest in the expected format.
-
 
 ``` { .json title=boot-beauty.ign }
 {
@@ -291,9 +342,6 @@ The purpose of this field is very similar to [clusters.ignitionConfigOverride](.
 }
 ```
 
-##  5. <a name='StartZTP'></a>Start ZTP
+## 5. Start ZTP
 
 Once the `siteConfig` and optionally the `policyGenTemplates` are uploaded to the Git repo where Argo CD is monitoring, we are ready to push the sync button to start the whole process. Remember that the process should require Zero Touch.
-
-
-

--- a/hack/Dockerfile.markdownlint
+++ b/hack/Dockerfile.markdownlint
@@ -1,0 +1,6 @@
+FROM fedora
+WORKDIR /workdir
+RUN dnf install -y git golang
+COPY install-markdownlint.sh /tmp
+RUN /tmp/install-markdownlint.sh
+ENTRYPOINT /workdir/hack/markdownlint.sh

--- a/hack/install-markdownlint.sh
+++ b/hack/install-markdownlint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -xe
+
+cat /etc/redhat-release || echo "No /etc/redhat-release"
+
+if grep -q 'Red Hat Enterprise Linux' /etc/redhat-release; then
+    # install the config file for the RPM repository with node 14
+    # steps taken from https://rpm.nodesource.com/setup_14.x
+    yum module disable -y nodejs
+    curl -sL -o '/tmp/nodesource.rpm' 'https://rpm.nodesource.com/pub_14.x/el/8/x86_64/nodesource-release-el8-1.noarch.rpm'
+    rpm -i --nosignature --force /tmp/nodesource.rpm
+    yum -y install nodejs
+else
+    # Fedora has a module we can use
+    dnf -y module enable nodejs:14
+    dnf -y install nodejs
+fi
+
+npm install -g markdownlint@v0.25.1 markdownlint-cli2@v0.4.0

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+# trap errors, including the exit code from the command failed
+trap 'handle_exit $?' EXIT
+
+function handle_exit {
+    # If the exit code we were given indicates an error, suggest that
+    # the author run the linter locally.
+    if [ "$1" != "0" ]; then
+    cat - <<EOF
+
+To run the linter on a Linux system with podman, run "make markdownlint"
+after committing your changes locally.
+
+EOF
+    fi
+}
+
+markdownlint-cli2 '**/*.md' !'vendor/**/*.md'
+


### PR DESCRIPTION
Updated markdown files with tables of content.

Added markdownlint with rules based on openshift/enhancements, resolving warnings/issues raised within existing markdown docs.