### PR TITLE
CNF-8601: Add regression test suite

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,4 +1,5 @@
+# SC1091: Not following: X: openBinaryFile: does not exist
 # SC2046: Quote this to prevent word splitting.
 # SC2086: Double quote to prevent globbing and word splitting.
 # SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
-disable=SC2046,SC2086,SC2181
+disable=SC1091,SC2046,SC2086,SC2181

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ COPY policy.json /etc/containers/policy.json
 
 COPY --from=builder /workspace/_output/ /usr/local/bin/
 
+RUN mkdir /usr/local/bin/regression-tests
+COPY regression/regression-suite*.sh /usr/local/bin/
+COPY regression/regression-test-*.sh /usr/local/bin/regression-tests/
+
 # no tool is more important than others
 ENTRYPOINT ["/run.sh"]
 CMD ["/help.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,6 +21,10 @@ COPY help.sh /help.sh
 
 COPY --from=builder /workspace/_output/ /usr/local/bin/
 
+RUN mkdir /usr/local/bin/regression-tests
+COPY regression/regression-suite*.sh /usr/local/bin/
+COPY regression/regression-test-*.sh /usr/local/bin/regression-tests/
+
 # no tool is more important than others
 ENTRYPOINT ["/run.sh"]
 CMD ["/help.sh"]

--- a/HACKING.md
+++ b/HACKING.md
@@ -5,6 +5,7 @@
   - [Linter tests](#linter-tests)
   - [Updates to extract-ai.sh and extract-ocp.sh](#updates-to-extract-aish-and-extract-ocpsh)
   - [Building the image](#building-the-image)
+  - [Regression testing](#regression-testing)
 
 ## Makefile targets
 
@@ -41,4 +42,64 @@ To build the image, run the `image` make target, or run the `push` make target t
 
 ```bash
 make REPOOWNER=${USER} push
+```
+
+## Regression testing
+
+A regression test suite utility is built into the image. It requires the pull secrets in `/root/.docker/config.json`, similar to
+the `download` command, as it will run `oc-mirror`, but it will avoid downloading the images. New tests should be added in the regression
+folder as needed. In addition, developers should run the regression tests prior to posting a pull request.
+
+```console
+[root@host core]# time podman run -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- regression-suite.sh
+################################################################################
+Wed May 24 18:39:26 UTC 2023: Running test: du-profile
+################################################################################
+Wed May 24 18:43:54 UTC 2023: Running test: generate-imageset
+/usr/local/bin/regression-tests/regression-test-generate-imageset.sh: line 76: [: /mnt/testsuite/imageset.yaml: integer expression expected
+################################################################################
+Wed May 24 18:43:54 UTC 2023: Running test: invalid-acm-version-format
+################################################################################
+Wed May 24 18:43:54 UTC 2023: Running test: invalid-mce-version-format
+################################################################################
+Wed May 24 18:43:54 UTC 2023: Running test: invalid-version-format
+################################################################################
+Wed May 24 18:43:54 UTC 2023: Running test: keep-stale
+Stale file found: /mnt/testsuite/not-a-real-image@sha256_1234567890123456789012345678901234567890123456789012345678901234.tgz
+################################################################################
+Wed May 24 18:46:48 UTC 2023: Running test: stale-cleanup
+################################################################################
+Wed May 24 18:49:41 UTC 2023: Running test: unavailable-acm-and-mce-versions
+################################################################################
+Wed May 24 18:51:39 UTC 2023: Running test: unavailable-acm-version
+################################################################################
+Wed May 24 18:53:35 UTC 2023: Running test: unavailable-mce-version
+################################################################################
+Wed May 24 18:54:32 UTC 2023: Running test: unknown-option
+################################################################################
+
+Test Results:
+
+Test Name                                 Status
+========================================  ==========
+du-profile                                PASSED
+generate-imageset                         PASSED
+invalid-acm-version-format                PASSED
+invalid-mce-version-format                PASSED
+invalid-version-format                    PASSED
+keep-stale                                PASSED
+stale-cleanup                             PASSED
+unavailable-acm-and-mce-versions          PASSED
+unavailable-acm-version                   PASSED
+unavailable-mce-version                   PASSED
+unknown-option                            PASSED
+
+Number of tests run:  11
+Total passed:         11
+Total failed:          0
+
+real    15m7.076s
+user    0m0.510s
+sys     0m0.383s
+[root@host core]#
 ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -51,31 +51,30 @@ the `download` command, as it will run `oc-mirror`, but it will avoid downloadin
 folder as needed. In addition, developers should run the regression tests prior to posting a pull request.
 
 ```console
-[root@host core]# time podman run -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- regression-suite.sh
+[root@host core]# time podman run -v /var/lib/kubelet/config.json:/root/.docker/config.json:Z --rm quay.io/openshift-kni/telco-ran-tools:latest -- regression-suite.sh
 ################################################################################
-Wed May 24 18:39:26 UTC 2023: Running test: du-profile
+Mon May 29 13:25:28 UTC 2023: Running test: du-profile
 ################################################################################
-Wed May 24 18:43:54 UTC 2023: Running test: generate-imageset
-/usr/local/bin/regression-tests/regression-test-generate-imageset.sh: line 76: [: /mnt/testsuite/imageset.yaml: integer expression expected
+Mon May 29 13:30:02 UTC 2023: Running test: generate-imageset
 ################################################################################
-Wed May 24 18:43:54 UTC 2023: Running test: invalid-acm-version-format
+Mon May 29 13:30:02 UTC 2023: Running test: invalid-acm-version-format
 ################################################################################
-Wed May 24 18:43:54 UTC 2023: Running test: invalid-mce-version-format
+Mon May 29 13:30:02 UTC 2023: Running test: invalid-mce-version-format
 ################################################################################
-Wed May 24 18:43:54 UTC 2023: Running test: invalid-version-format
+Mon May 29 13:30:02 UTC 2023: Running test: invalid-version-format
 ################################################################################
-Wed May 24 18:43:54 UTC 2023: Running test: keep-stale
+Mon May 29 13:30:02 UTC 2023: Running test: keep-stale
 Stale file found: /mnt/testsuite/not-a-real-image@sha256_1234567890123456789012345678901234567890123456789012345678901234.tgz
 ################################################################################
-Wed May 24 18:46:48 UTC 2023: Running test: stale-cleanup
+Mon May 29 13:32:58 UTC 2023: Running test: stale-cleanup
 ################################################################################
-Wed May 24 18:49:41 UTC 2023: Running test: unavailable-acm-and-mce-versions
+Mon May 29 13:35:54 UTC 2023: Running test: unavailable-acm-and-mce-versions
 ################################################################################
-Wed May 24 18:51:39 UTC 2023: Running test: unavailable-acm-version
+Mon May 29 13:37:53 UTC 2023: Running test: unavailable-acm-version
 ################################################################################
-Wed May 24 18:53:35 UTC 2023: Running test: unavailable-mce-version
+Mon May 29 13:39:49 UTC 2023: Running test: unavailable-mce-version
 ################################################################################
-Wed May 24 18:54:32 UTC 2023: Running test: unknown-option
+Mon May 29 13:40:48 UTC 2023: Running test: unknown-option
 ################################################################################
 
 Test Results:
@@ -98,8 +97,8 @@ Number of tests run:  11
 Total passed:         11
 Total failed:          0
 
-real    15m7.076s
-user    0m0.510s
-sys     0m0.383s
+real    15m22.912s
+user    0m1.519s
+sys     0m0.667s
 [root@host core]#
 ```

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -42,6 +42,9 @@ var DefaultParallelization = int(float32(runtime.NumCPU()) * 0.8)
 // MaxRequeues is the number of retries allowed for download reattempts.
 const MaxRequeues = 3
 
+// TestMode indicates whether to create a dummy tarball rather than download the image.
+var TestMode = false
+
 // splitVersion will split a version string into an X.Y string and a Z string.
 func splitVersion(version string) (xy, z string) {
 	if version != "" {
@@ -130,6 +133,7 @@ var downloadCmd = &cobra.Command{
 		maxParallel, _ := cmd.Flags().GetInt("parallel")
 		acmVersion, _ := cmd.Flags().GetString("acm-version")
 		mceVersion, _ := cmd.Flags().GetString("mce-version")
+		TestMode, _ = cmd.Flags().GetBool("testmode")
 
 		// Validate cmdline parameters
 		if len(args) > 0 {
@@ -160,7 +164,7 @@ var downloadCmd = &cobra.Command{
 		}
 
 		if !versionRE.MatchString(mceVersion) {
-			return fmt.Errorf("Invalid mce-version specified. X.Y.Z format expected: %s", hubVersion)
+			return fmt.Errorf("Invalid mce-version specified. X.Y.Z format expected: %s", mceVersion)
 		}
 
 		if duProfile && acmVersion == "" {
@@ -169,7 +173,7 @@ var downloadCmd = &cobra.Command{
 
 		if acmVersion != "" {
 			if !versionRE.MatchString(acmVersion) {
-				return fmt.Errorf("Invalid acm-version specified. X.Y.Z format expected: %s", hubVersion)
+				return fmt.Errorf("Invalid acm-version specified. X.Y.Z format expected: %s", acmVersion)
 			}
 		}
 
@@ -214,6 +218,7 @@ func init() {
 	downloadCmd.Flags().StringP("acm-version", "", "", "Advanced Cluster Management operator version, in X.Y.Z format")
 	downloadCmd.Flags().StringP("mce-version", "", "", "MultiCluster Engine operator version, in X.Y.Z format")
 	downloadCmd.Flags().IntP("parallel", "p", DefaultParallelization, "Maximum parallel downloads")
+	downloadCmd.Flags().Bool("testmode", false, "Create dummy image files rather than download")
 	rootCmd.AddCommand(downloadCmd)
 }
 
@@ -406,6 +411,19 @@ func runOcMirrorCommand(tmpDir, folder string) error {
 // imageDownload handles the image download job.
 func imageDownload(workerID int, image ImageMapping, folder string) error {
 	artifactTar := image.Artifact + ".tgz"
+
+	if TestMode {
+		fmt.Fprintf(os.Stdout, "TestMode: Creating dummy image file: %s", artifactTar)
+
+		time.Sleep(time.Second * 3) // Sleep 3 seconds before creating file
+
+		out, err := os.OpenFile(path.Join(folder, artifactTar), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+		return nil
+	}
 
 	fmt.Fprintf(os.Stdout, "Downloading: %s\n", image.Image)
 

--- a/regression/regression-suite-common.sh
+++ b/regression/regression-suite-common.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+#
+# Common functions and constants for telco-ran-tools built-in regression test suite
+#
+
+#
+# Constants
+#
+# shellcheck disable=SC2034
+DEFAULT_TEST_RELEASE="4.12.15"
+DEFAULT_TEST_RELEASE_Y="4.12"
+DEFAULT_TEST_UNAVAILABLE_VERSION="99.99.99"
+DEFAULT_TEST_BAD_VERSION_FORMAT="4.12.notaversion"
+DEFAULT_TEST_ACM_RELEASE="2.7.0"
+DEFAULT_TEST_ACM_RELEASE_Y="2.7"
+DEFAULT_TEST_ACM_BAD_VERSION_FORMAT="2.7.notaversion"
+DEFAULT_TEST_MCE_RELEASE="2.2.0"
+DEFAULT_TEST_MCE_RELEASE_Y="2.2"
+DEFAULT_TEST_MCE_BAD_VERSION_FORMAT="2.2.notaversion"
 
 #
 # Check mapping.txt to ensure all files are downloaded and in either ai-images.txt or ocp-images.txt

--- a/regression/regression-suite-functions.sh
+++ b/regression/regression-suite-functions.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+#
+# Check mapping.txt to ensure all files are downloaded and in either ai-images.txt or ocp-images.txt
+#
+function verify_downloaded_files {
+    local missing=0
+    local verified=0
+
+    local mapping
+    local img
+    local imgfile
+
+    for mapping in $(<"${TESTFOLDER}/mapping.txt"); do
+        img=$(basename ${mapping/=*})
+
+        # Image must be in either ai-images.txt or ocp-images.txt
+        if ! grep -q "/${img}$" "${TESTFOLDER}/ai-images.txt" "${TESTFOLDER}/ocp-images.txt"; then
+            echo "Missing from images files: ${img}"
+            missing=$((missing+1))
+            continue
+        else
+            verified=$((verified+1))
+        fi
+
+        # Image filename has the : replaced with _, with a .tgz suffix
+        imgfile="${TESTFOLDER}/${img/:/_}.tgz"
+        if [ ! -f "${imgfile}" ]; then
+            echo "File not found: ${imgfile}"
+            missing=$((missing+1))
+            continue
+        fi
+    done
+
+    if [ "${verified}" -eq 0 ]; then
+        echo "Verification failed due to missing files in ${TESTFOLDER}/mapping.txt"
+        return 1
+    fi
+
+    if [ "${missing}" -gt 0 ]; then
+        echo "Verification failed due to missing files or filenames"
+        return 1
+    fi
+
+    return 0
+}
+
+#
+# Check for stale image files
+#
+function check_for_stale_image_files {
+    local -a expected_files
+    local mapping
+    local img
+    local imgfile
+
+    for mapping in $(<"${TESTFOLDER}/mapping.txt"); do
+        img=$(basename ${mapping/=*})
+
+        # Image filename has the : replaced with _, with a .tgz suffix
+        expected_files+=("${TESTFOLDER}/${img/:/_}.tgz")
+    done
+
+    local stale=0
+
+    for imgfile in "${TESTFOLDER}"/*.tgz; do
+        if [[ ! "${expected_files[*]}" =~ ${imgfile} ]]; then
+            echo "Stale file found: ${imgfile}"
+            stale=$((stale+1))
+        fi
+    done
+
+    return "${stale}"
+}
+

--- a/regression/regression-suite.sh
+++ b/regression/regression-suite.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Runs a set of tests within the telco-ran-tools container
+#
+
+PROG=$(basename "$0")
+SCRIPTDIR=$(dirname $(readlink -f "$0"))
+
+# Location of regression tests
+declare TESTDIR="${SCRIPTDIR}/regression-tests"
+
+# Default folder
+declare FOLDER="/mnt"
+
+#
+# Usage
+#
+function usage {
+    cat <<EOF
+This script runs a series of regression tests within the telco-ran-tools container.
+
+Usage: ${PROG}
+Options:
+EOF
+    exit 1
+}
+
+#
+# Display a separator
+#
+function separator {
+    printf '#%.0s' {1..80}; printf '\n'
+}
+
+#
+# Process cmdline arguments
+#
+
+longopts=(
+    "help"
+    "folder:"
+)
+
+longopts_str=$(IFS=,; echo "${longopts[*]}")
+
+if ! OPTS=$(getopt -o "hf:" --long "${longopts_str}" --name "$0" -- "$@"); then
+    usage
+    exit 1
+fi
+
+eval set -- "${OPTS}"
+
+while :; do
+    case "$1" in
+        -f|--folder)
+            FOLDER="${2}"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+# Make TESTFOLDER available to tests
+export TESTFOLDER="${FOLDER}/testsuite"
+
+if [ -d "${TESTFOLDER}" ]; then
+    echo "Content from previous test run exists. Please delete: ${TESTFOLDER}" >&2
+    exit 1
+fi
+
+# Run the regression tests
+declare -A results
+
+for testscript in "${TESTDIR}"/regression-test-*.sh; do
+    if ! mkdir "${TESTFOLDER}" ; then
+        echo "Unable to create ${TESTFOLDER}" >&2
+        exit 1
+    fi
+
+    WORKDIR=$(mktemp -d)
+    cd "${WORKDIR}" || exit 1
+
+    name=$(echo "${testscript}" | sed -r 's#.*/regression-test-(.*)\.sh$#\1#')
+    separator
+    echo "$(date): Running test: ${name}"
+
+    ${testscript}
+    results["${name}"]=$?
+
+    cd /
+    rm -rf "${WORKDIR}"
+    rm -rf "${TESTFOLDER}"
+done
+
+separator
+
+# Report results
+echo -e '\nTest Results:\n'
+printf '%-40s  %-10s\n' 'Test Name' 'Status'
+printf '=%.0s' {1..40} ; printf '  '; printf '=%.0s' {1..10}; printf '\n'
+
+total_passed=0
+total_failed=0
+
+mapfile -t sorted_names < <( IFS=$'\n'; sort -u <<<"${!results[*]}" )
+for name in "${sorted_names[@]}"; do
+    if [ "${results[${name}]}" -eq 0 ]; then
+        status="PASSED"
+        total_passed=$((total_passed+1))
+    else
+        status="FAILED"
+        total_failed=$((total_failed+1))
+    fi
+    printf '%-40s  %-10s\n' "${name}" "${status}"
+done
+
+printf '\n'
+
+printf '%-20s %3d\n' 'Number of tests run:' ${#results[@]}
+printf '%-20s %3d\n' 'Total passed:' ${total_passed}
+printf '%-20s %3d\n' 'Total failed:' ${total_failed}
+
+if [ "${total_failed}" -gt 0 ]; then
+    exit 1
+fi
+
+exit 0
+

--- a/regression/regression-test-du-profile.sh
+++ b/regression/regression-test-du-profile.sh
@@ -3,16 +3,16 @@
 # Runs invalid parameter handling tests
 #
 
-source /usr/local/bin/regression-suite-functions.sh
+source /usr/local/bin/regression-suite-common.sh
 
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.0 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     --du-profile \
-    --acm-version 2.7.0 \
+    --acm-version "${DEFAULT_TEST_ACM_RELEASE}" \
     >& command-output.txt
 rc=$?
 
@@ -37,9 +37,9 @@ kind: ImageSetConfiguration
 mirror:
   platform:
     channels:
-    - name: stable-4.12
-      minVersion: 4.12.15
-      maxVersion: 4.12.15
+    - name: stable-${DEFAULT_TEST_RELEASE_Y}
+      minVersion: ${DEFAULT_TEST_RELEASE}
+      maxVersion: ${DEFAULT_TEST_RELEASE}
   additionalImages:
 #
 # Example operators specification:
@@ -58,18 +58,18 @@ mirror:
 #          channels:
 #            - name: 'stable'
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v${DEFAULT_TEST_RELEASE_Y}
       packages:
         - name: multicluster-engine
           channels:
-            - name: 'stable-2.2'
-              minVersion: 2.2.0
-              maxVersion: 2.2.0
+            - name: 'stable-${DEFAULT_TEST_MCE_RELEASE_Y}'
+              minVersion: ${DEFAULT_TEST_MCE_RELEASE}
+              maxVersion: ${DEFAULT_TEST_MCE_RELEASE}
         - name: advanced-cluster-management
           channels:
-            - name: 'release-2.7'
-              minVersion: 2.7.0
-              maxVersion: 2.7.0
+            - name: 'release-${DEFAULT_TEST_ACM_RELEASE_Y}'
+              minVersion: ${DEFAULT_TEST_ACM_RELEASE}
+              maxVersion: ${DEFAULT_TEST_ACM_RELEASE}
         - name: local-storage-operator
           channels:
             - name: 'stable'
@@ -84,14 +84,14 @@ mirror:
             - name: 'stable'
         - name: lvms-operator
           channels:
-            - name: 'stable-4.12'
+            - name: 'stable-${DEFAULT_TEST_RELEASE_Y}'
         - name: amq7-interconnect-operator
           channels:
             - name: '1.10.x'
         - name: bare-metal-event-relay
           channels:
             - name: 'stable'
-    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.12
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v${DEFAULT_TEST_RELEASE_Y}
       packages:
         - name: sriov-fec
           channels:

--- a/regression/regression-test-du-profile.sh
+++ b/regression/regression-test-du-profile.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+source /usr/local/bin/regression-suite-functions.sh
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.0 \
+    -r 4.12.15 \
+    --du-profile \
+    --acm-version 2.7.0 \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Command returned rc=${rc}"
+    exit 1
+fi
+
+# Validate imageset.yaml
+if [ ! -f "${TESTFOLDER}/imageset.yaml" ]; then
+    echo "Could not find ${TESTFOLDER}/imageset.yaml"
+    exit 1
+fi
+
+cat <<EOF >expected-imageset.yaml
+
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  platform:
+    channels:
+    - name: stable-4.12
+      minVersion: 4.12.15
+      maxVersion: 4.12.15
+  additionalImages:
+#
+# Example operators specification:
+#
+#  operators:
+#    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
+#      full: true
+#      packages:
+#        - name: ptp-operator
+#          channels:
+#            - name: 'stable'
+#        - name: sriov-network-operator
+#          channels:
+#            - name: 'stable'
+#        - name: cluster-logging
+#          channels:
+#            - name: 'stable'
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
+      packages:
+        - name: multicluster-engine
+          channels:
+            - name: 'stable-2.2'
+              minVersion: 2.2.0
+              maxVersion: 2.2.0
+        - name: advanced-cluster-management
+          channels:
+            - name: 'release-2.7'
+              minVersion: 2.7.0
+              maxVersion: 2.7.0
+        - name: local-storage-operator
+          channels:
+            - name: 'stable'
+        - name: ptp-operator
+          channels:
+            - name: 'stable'
+        - name: sriov-network-operator
+          channels:
+            - name: 'stable'
+        - name: cluster-logging
+          channels:
+            - name: 'stable'
+        - name: lvms-operator
+          channels:
+            - name: 'stable-4.12'
+        - name: amq7-interconnect-operator
+          channels:
+            - name: '1.10.x'
+        - name: bare-metal-event-relay
+          channels:
+            - name: 'stable'
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.12
+      packages:
+        - name: sriov-fec
+          channels:
+            - name: 'stable'
+EOF
+
+if ! diff expected-imageset.yaml "${TESTFOLDER}/imageset.yaml" ; then
+    echo "Generated imageset.yaml doesn't match expected content."
+    exit 1
+fi
+
+# Verify all expected image files exist
+if ! verify_downloaded_files ; then
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-generate-imageset.sh
+++ b/regression/regression-test-generate-imageset.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+source /usr/local/bin/regression-suite-functions.sh
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.0 \
+    -r 4.12.15 \
+    --generate-imageset \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Command returned rc=${rc}"
+    exit 1
+fi
+
+# Verify content of imageset, and that it is the only file in the TESTFOLDER directory
+
+if [ ! -f "${TESTFOLDER}/imageset.yaml" ]; then
+    echo "Could not find ${TESTFOLDER}/imageset.yaml"
+    exit 1
+fi
+
+cat <<EOF >expected-imageset.yaml
+
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  platform:
+    channels:
+    - name: stable-4.12
+      minVersion: 4.12.15
+      maxVersion: 4.12.15
+  additionalImages:
+#
+# Example operators specification:
+#
+#  operators:
+#    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
+#      full: true
+#      packages:
+#        - name: ptp-operator
+#          channels:
+#            - name: 'stable'
+#        - name: sriov-network-operator
+#          channels:
+#            - name: 'stable'
+#        - name: cluster-logging
+#          channels:
+#            - name: 'stable'
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
+      packages:
+        - name: multicluster-engine
+          channels:
+            - name: 'stable-2.2'
+              minVersion: 2.2.0
+              maxVersion: 2.2.0
+EOF
+
+if ! diff expected-imageset.yaml "${TESTFOLDER}/imageset.yaml" ; then
+    echo "Generated imageset.yaml doesn't match expected content."
+    exit 1
+fi
+
+numfiles=$(find "${TESTFOLDER}" -type f)
+if [ "${numfiles}" -ne 1 ]; then
+    echo "Expected to find 1 file in ${TESTFOLDER}, but found ${numfiles}"
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-generate-imageset.sh
+++ b/regression/regression-test-generate-imageset.sh
@@ -3,14 +3,14 @@
 # Runs invalid parameter handling tests
 #
 
-source /usr/local/bin/regression-suite-functions.sh
+source /usr/local/bin/regression-suite-common.sh
 
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.0 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     --generate-imageset \
     >& command-output.txt
 rc=$?
@@ -37,9 +37,9 @@ kind: ImageSetConfiguration
 mirror:
   platform:
     channels:
-    - name: stable-4.12
-      minVersion: 4.12.15
-      maxVersion: 4.12.15
+    - name: stable-${DEFAULT_TEST_RELEASE_Y}
+      minVersion: ${DEFAULT_TEST_RELEASE}
+      maxVersion: ${DEFAULT_TEST_RELEASE}
   additionalImages:
 #
 # Example operators specification:
@@ -58,13 +58,13 @@ mirror:
 #          channels:
 #            - name: 'stable'
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.12
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v${DEFAULT_TEST_RELEASE_Y}
       packages:
         - name: multicluster-engine
           channels:
-            - name: 'stable-2.2'
-              minVersion: 2.2.0
-              maxVersion: 2.2.0
+            - name: 'stable-${DEFAULT_TEST_MCE_RELEASE_Y}'
+              minVersion: ${DEFAULT_TEST_MCE_RELEASE}
+              maxVersion: ${DEFAULT_TEST_MCE_RELEASE}
 EOF
 
 if ! diff expected-imageset.yaml "${TESTFOLDER}/imageset.yaml" ; then
@@ -72,7 +72,8 @@ if ! diff expected-imageset.yaml "${TESTFOLDER}/imageset.yaml" ; then
     exit 1
 fi
 
-numfiles=$(find "${TESTFOLDER}" -type f)
+declare -i numfiles=0
+numfiles=$(find "${TESTFOLDER}" -type f | wc -l)
 if [ "${numfiles}" -ne 1 ]; then
     echo "Expected to find 1 file in ${TESTFOLDER}, but found ${numfiles}"
     exit 1

--- a/regression/regression-test-invalid-acm-version-format.sh
+++ b/regression/regression-test-invalid-acm-version-format.sh
@@ -3,14 +3,16 @@
 # Runs invalid parameter handling tests
 #
 
+source /usr/local/bin/regression-suite-common.sh
+
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.0 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     --du-profile \
-    --acm-version 2.7.invalid \
+    --acm-version "${DEFAULT_TEST_ACM_BAD_VERSION_FORMAT}" \
     >& command-output.txt
 rc=$?
 
@@ -21,7 +23,7 @@ if [ "${rc}" -eq 0 ]; then
 fi
 
 # Check for expected error message
-if ! grep -q 'Error: Invalid acm-version specified. X.Y.Z format expected: 2.7.invalid' command-output.txt ; then
+if ! grep -q "Error: Invalid acm-version specified. X.Y.Z format expected: ${DEFAULT_TEST_ACM_BAD_VERSION_FORMAT}" command-output.txt ; then
     echo "Expected error message not found in command output."
     exit 1
 fi

--- a/regression/regression-test-invalid-acm-version-format.sh
+++ b/regression/regression-test-invalid-acm-version-format.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.0 \
+    -r 4.12.15 \
+    --du-profile \
+    --acm-version 2.7.invalid \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a non-zero status
+if [ "${rc}" -eq 0 ]; then
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+# Check for expected error message
+if ! grep -q 'Error: Invalid acm-version specified. X.Y.Z format expected: 2.7.invalid' command-output.txt ; then
+    echo "Expected error message not found in command output."
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-invalid-mce-version-format.sh
+++ b/regression/regression-test-invalid-mce-version-format.sh
@@ -3,12 +3,14 @@
 # Runs invalid parameter handling tests
 #
 
+source /usr/local/bin/regression-suite-common.sh
+
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.invalid \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_MCE_BAD_VERSION_FORMAT}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     >& command-output.txt
 rc=$?
 
@@ -19,7 +21,7 @@ if [ "${rc}" -eq 0 ]; then
 fi
 
 # Check for expected error message
-if ! grep -q 'Error: Invalid mce-version specified. X.Y.Z format expected: 2.2.invalid' command-output.txt ; then
+if ! grep -q "Error: Invalid mce-version specified. X.Y.Z format expected: ${DEFAULT_TEST_MCE_BAD_VERSION_FORMAT}" command-output.txt ; then
     echo "Expected error message not found in command output."
     exit 1
 fi

--- a/regression/regression-test-invalid-mce-version-format.sh
+++ b/regression/regression-test-invalid-mce-version-format.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.invalid \
+    -r 4.12.15 \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a non-zero status
+if [ "${rc}" -eq 0 ]; then
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+# Check for expected error message
+if ! grep -q 'Error: Invalid mce-version specified. X.Y.Z format expected: 2.2.invalid' command-output.txt ; then
+    echo "Expected error message not found in command output."
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-invalid-version-format.sh
+++ b/regression/regression-test-invalid-version-format.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.0 \
+    -r 4.12.notaversion \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a non-zero status
+if [ "${rc}" -eq 0 ]; then
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+# Check for expected error message
+if ! grep -q 'Error: Invalid release specified. X.Y.Z format expected: 4.12.notaversion' command-output.txt ; then
+    echo "Expected error message not found in command output."
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-invalid-version-format.sh
+++ b/regression/regression-test-invalid-version-format.sh
@@ -3,12 +3,14 @@
 # Runs invalid parameter handling tests
 #
 
+source /usr/local/bin/regression-suite-common.sh
+
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.0 \
-    -r 4.12.notaversion \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_BAD_VERSION_FORMAT}" \
     >& command-output.txt
 rc=$?
 
@@ -19,7 +21,7 @@ if [ "${rc}" -eq 0 ]; then
 fi
 
 # Check for expected error message
-if ! grep -q 'Error: Invalid release specified. X.Y.Z format expected: 4.12.notaversion' command-output.txt ; then
+if ! grep -q "Error: Invalid release specified. X.Y.Z format expected: ${DEFAULT_TEST_BAD_VERSION_FORMAT}" command-output.txt ; then
     echo "Expected error message not found in command output."
     exit 1
 fi

--- a/regression/regression-test-keep-stale.sh
+++ b/regression/regression-test-keep-stale.sh
@@ -3,7 +3,7 @@
 # Runs invalid parameter handling tests
 #
 
-source /usr/local/bin/regression-suite-functions.sh
+source /usr/local/bin/regression-suite-common.sh
 
 # Create a fake image file for stale cleanup test
 echo "Test image" > "${TESTFOLDER}"/not-a-real-image@sha256_1234567890123456789012345678901234567890123456789012345678901234.tgz
@@ -12,8 +12,8 @@ echo "Test image" > "${TESTFOLDER}"/not-a-real-image@sha256_12345678901234567890
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.0 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     >& command-output.txt
 rc=$?
 

--- a/regression/regression-test-keep-stale.sh
+++ b/regression/regression-test-keep-stale.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+source /usr/local/bin/regression-suite-functions.sh
+
+# Create a fake image file for stale cleanup test
+echo "Test image" > "${TESTFOLDER}"/not-a-real-image@sha256_1234567890123456789012345678901234567890123456789012345678901234.tgz
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.0 \
+    -r 4.12.15 \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Command returned rc=${rc}"
+    exit 1
+fi
+
+# Verify all expected image files exist
+if ! verify_downloaded_files ; then
+    exit 1
+fi
+
+# We expect to see our stale file remaining
+if check_for_stale_image_files ; then
+    echo "Error: No stale files detected"
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-stale-cleanup.sh
+++ b/regression/regression-test-stale-cleanup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+source /usr/local/bin/regression-suite-functions.sh
+
+# Create a fake image file for stale cleanup test
+echo "Test image" > "${TESTFOLDER}"/not-a-real-image@sha256_1234567890123456789012345678901234567890123456789012345678901234.tgz
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.0 \
+    -r 4.12.15 \
+    -s \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Command returned rc=${rc}"
+    exit 1
+fi
+
+# Verify all expected image files exist
+if ! verify_downloaded_files ; then
+    exit 1
+fi
+
+if ! check_for_stale_image_files ; then
+    echo "Stale files detected"
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-stale-cleanup.sh
+++ b/regression/regression-test-stale-cleanup.sh
@@ -3,7 +3,7 @@
 # Runs invalid parameter handling tests
 #
 
-source /usr/local/bin/regression-suite-functions.sh
+source /usr/local/bin/regression-suite-common.sh
 
 # Create a fake image file for stale cleanup test
 echo "Test image" > "${TESTFOLDER}"/not-a-real-image@sha256_1234567890123456789012345678901234567890123456789012345678901234.tgz
@@ -12,8 +12,8 @@ echo "Test image" > "${TESTFOLDER}"/not-a-real-image@sha256_12345678901234567890
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.0 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     -s \
     >& command-output.txt
 rc=$?

--- a/regression/regression-test-unavailable-acm-and-mce-versions.sh
+++ b/regression/regression-test-unavailable-acm-and-mce-versions.sh
@@ -3,14 +3,16 @@
 # Runs invalid parameter handling tests
 #
 
+source /usr/local/bin/regression-suite-common.sh
+
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 99.99.99 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_UNAVAILABLE_VERSION}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     --du-profile \
-    --acm-version 99.99.99 \
+    --acm-version "${DEFAULT_TEST_UNAVAILABLE_VERSION}" \
     >& command-output.txt
 rc=$?
 
@@ -21,8 +23,8 @@ if [ "${rc}" -eq 0 ]; then
 fi
 
 # Check for expected error message
-if ! grep -q 'multicluster-engine version 99.99.99 not found in channel' command-output.txt || \
-    ! grep -q 'advanced-cluster-management version 99.99.99 not found in channel' command-output.txt || \
+if ! grep -q "multicluster-engine version ${DEFAULT_TEST_UNAVAILABLE_VERSION} not found in channel" command-output.txt || \
+    ! grep -q "advanced-cluster-management version ${DEFAULT_TEST_UNAVAILABLE_VERSION} not found in channel" command-output.txt || \
     ! grep -q 'Version checks failed for 2 operator' command-output.txt ; then
     echo "Expected error message not found in command output."
     exit 1

--- a/regression/regression-test-unavailable-acm-and-mce-versions.sh
+++ b/regression/regression-test-unavailable-acm-and-mce-versions.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 99.99.99 \
+    -r 4.12.15 \
+    --du-profile \
+    --acm-version 99.99.99 \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a non-zero status
+if [ "${rc}" -eq 0 ]; then
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+# Check for expected error message
+if ! grep -q 'multicluster-engine version 99.99.99 not found in channel' command-output.txt || \
+    ! grep -q 'advanced-cluster-management version 99.99.99 not found in channel' command-output.txt || \
+    ! grep -q 'Version checks failed for 2 operator' command-output.txt ; then
+    echo "Expected error message not found in command output."
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-unavailable-acm-version.sh
+++ b/regression/regression-test-unavailable-acm-version.sh
@@ -3,14 +3,16 @@
 # Runs invalid parameter handling tests
 #
 
+source /usr/local/bin/regression-suite-common.sh
+
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.0 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     --du-profile \
-    --acm-version 99.99.99 \
+    --acm-version "${DEFAULT_TEST_UNAVAILABLE_VERSION}" \
     >& command-output.txt
 rc=$?
 
@@ -21,7 +23,7 @@ if [ "${rc}" -eq 0 ]; then
 fi
 
 # Check for expected error message
-if ! grep -q 'advanced-cluster-management version 99.99.99 not found in channel' command-output.txt || \
+if ! grep -q "advanced-cluster-management version ${DEFAULT_TEST_UNAVAILABLE_VERSION} not found in channel" command-output.txt || \
     ! grep -q 'Version checks failed for 1 operator' command-output.txt ; then
     echo "Expected error message not found in command output."
     exit 1

--- a/regression/regression-test-unavailable-acm-version.sh
+++ b/regression/regression-test-unavailable-acm-version.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.0 \
+    -r 4.12.15 \
+    --du-profile \
+    --acm-version 99.99.99 \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a non-zero status
+if [ "${rc}" -eq 0 ]; then
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+# Check for expected error message
+if ! grep -q 'advanced-cluster-management version 99.99.99 not found in channel' command-output.txt || \
+    ! grep -q 'Version checks failed for 1 operator' command-output.txt ; then
+    echo "Expected error message not found in command output."
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-unavailable-mce-version.sh
+++ b/regression/regression-test-unavailable-mce-version.sh
@@ -3,12 +3,14 @@
 # Runs invalid parameter handling tests
 #
 
+source /usr/local/bin/regression-suite-common.sh
+
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 99.99.99 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_UNAVAILABLE_VERSION}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     >& command-output.txt
 rc=$?
 
@@ -19,7 +21,7 @@ if [ "${rc}" -eq 0 ]; then
 fi
 
 # Check for expected error message
-if ! grep -q 'multicluster-engine version 99.99.99 not found in channel' command-output.txt || \
+if ! grep -q "multicluster-engine version ${DEFAULT_TEST_UNAVAILABLE_VERSION} not found in channel" command-output.txt || \
     ! grep -q 'Version checks failed for 1 operator' command-output.txt ; then
     echo "Expected error message not found in command output."
     exit 1

--- a/regression/regression-test-unavailable-mce-version.sh
+++ b/regression/regression-test-unavailable-mce-version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 99.99.99 \
+    -r 4.12.15 \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a non-zero status
+if [ "${rc}" -eq 0 ]; then
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+# Check for expected error message
+if ! grep -q 'multicluster-engine version 99.99.99 not found in channel' command-output.txt || \
+    ! grep -q 'Version checks failed for 1 operator' command-output.txt ; then
+    echo "Expected error message not found in command output."
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-unknown-option.sh
+++ b/regression/regression-test-unknown-option.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Runs invalid parameter handling tests
+#
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version 2.2.0 \
+    -r 4.12.15 \
+    --not-a-valid-option \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a non-zero status
+if [ "${rc}" -eq 0 ]; then
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+# Check for expected error message
+if ! grep -q 'Error: unknown flag: --not-a-valid-option' command-output.txt ; then
+    echo "Expected error message not found in command output."
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-unknown-option.sh
+++ b/regression/regression-test-unknown-option.sh
@@ -3,12 +3,14 @@
 # Runs invalid parameter handling tests
 #
 
+source /usr/local/bin/regression-suite-common.sh
+
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version 2.2.0 \
-    -r 4.12.15 \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
     --not-a-valid-option \
     >& command-output.txt
 rc=$?


### PR DESCRIPTION
This update adds a regression test suite to the telco-ran-tools image, which will run a series of download tests to verify existing functionality, such as invalid parameter handling and operator version checking.