### PR TITLE
CNF-8687: Add support for user-specified image filters

### DIFF
--- a/regression/regression-test-du-profile.sh
+++ b/regression/regression-test-du-profile.sh
@@ -25,6 +25,7 @@ fi
 
 # Validate imageset.yaml
 if [ ! -f "${TESTFOLDER}/imageset.yaml" ]; then
+    cat command-output.txt
     echo "Could not find ${TESTFOLDER}/imageset.yaml"
     exit 1
 fi

--- a/regression/regression-test-generate-imageset.sh
+++ b/regression/regression-test-generate-imageset.sh
@@ -25,6 +25,7 @@ fi
 # Verify content of imageset, and that it is the only file in the TESTFOLDER directory
 
 if [ ! -f "${TESTFOLDER}/imageset.yaml" ]; then
+    cat command-output.txt
     echo "Could not find ${TESTFOLDER}/imageset.yaml"
     exit 1
 fi

--- a/regression/regression-test-imgfilter-all-images.sh
+++ b/regression/regression-test-imgfilter-all-images.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Runs image filter file test, filtering all images
+#
+
+source /usr/local/bin/regression-suite-common.sh
+
+cat <<EOF > image-filter.yaml
+---
+patterns:
+  - .*
+EOF
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
+    --filter image-filter.yaml \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+mapping_lines=$(wc -l < "${TESTFOLDER}/mapping.txt")
+ai_image_lines=$(wc -l < "${TESTFOLDER}/ai-images.txt")
+ocp_image_lines=$(wc -l < "${TESTFOLDER}/ocp-images.txt")
+ignored_image_lines=$(wc -l < "${TESTFOLDER}/ignored-images.txt")
+
+if [ "${mapping_lines}" -eq 0 ]; then
+    cat command-output.txt
+    echo "Error: mapping.txt is empty"
+    exit 1
+fi
+
+if [ "${ai_image_lines}" -ne 0 ] && [ "${ocp_image_lines}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Error: Expected ai-images.txt and ocp-images.txt to be empty"
+    exit 1
+fi
+
+if [ "${ignored_image_lines}" -ne "${mapping_lines}" ]; then
+    cat command-output.txt
+    echo "Error: Expected ignored-images.txt to have same number of images as mapping.txt"
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-imgfilter-bad-yaml.sh
+++ b/regression/regression-test-imgfilter-bad-yaml.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 #
-# Runs invalid parameter handling tests
+# Runs image filter file test, with bad yaml
 #
 
 source /usr/local/bin/regression-suite-common.sh
+
+cat <<EOF > image-filter.yaml
+---
+patterns:
+  - [bad-yaml
+EOF
 
 # Run the command, capturing the output and RC
 factory-precaching-cli download \
     --testmode \
     -f "${TESTFOLDER}" \
-    --mce-version "${DEFAULT_TEST_UNAVAILABLE_VERSION}" \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
     -r "${DEFAULT_TEST_RELEASE}" \
-    --du-profile \
-    --acm-version "${DEFAULT_TEST_UNAVAILABLE_VERSION}" \
+    --filter image-filter.yaml \
     >& command-output.txt
 rc=$?
 
@@ -24,9 +29,7 @@ if [ "${rc}" -eq 0 ]; then
 fi
 
 # Check for expected error message
-if ! grep -q "multicluster-engine version ${DEFAULT_TEST_UNAVAILABLE_VERSION} not found in channel" command-output.txt || \
-    ! grep -q "advanced-cluster-management version ${DEFAULT_TEST_UNAVAILABLE_VERSION} not found in channel" command-output.txt || \
-    ! grep -q 'Version checks failed for 2 operator' command-output.txt ; then
+if ! grep -q "Error: yaml: line 3: did not find expected" command-output.txt ; then
     cat command-output.txt
     echo "Expected error message not found in command output."
     exit 1

--- a/regression/regression-test-imgfilter-multiple-images.sh
+++ b/regression/regression-test-imgfilter-multiple-images.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Runs image filter file test, filtering specific images
+#
+
+source /usr/local/bin/regression-suite-common.sh
+
+cat <<EOF > image-filter.yaml
+---
+patterns:
+  - aws
+  - azure
+  - cluster-curator-controller
+EOF
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
+    --filter image-filter.yaml \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+mapping_lines=$(wc -l < "${TESTFOLDER}/mapping.txt")
+downloaded_image_lines=$(sort -u "${TESTFOLDER}/ai-images.txt" "${TESTFOLDER}/ocp-images.txt" | wc -l)
+ignored_image_lines=$(wc -l < "${TESTFOLDER}/ignored-images.txt")
+
+if [ "${mapping_lines}" -eq 0 ]; then
+    cat command-output.txt
+    echo "Error: mapping.txt is empty"
+    exit 1
+fi
+
+if [ "${downloaded_image_lines}" -eq 0 ]; then
+    cat command-output.txt
+    echo "Error: Expected ai-images.txt and ocp-images.txt to have images"
+    exit 1
+fi
+
+if [ "$((downloaded_image_lines+ignored_image_lines))" -ne "${mapping_lines}" ]; then
+    cat command-output.txt
+    echo "Error: Expected sum of downloaded and ignored images to match mapping.txt entries"
+    exit 1
+fi
+
+# Verify filtered images show up in ignored-images.txt, but not ai-images.txt or ocp-images.txt
+mapfile -t filtered_images < <( grep -e aws -e azure -e cluster-curator-controller "${TESTFOLDER}/mapping.txt" | awk -F'=' '{print $1}' )
+for img in "${filtered_images[@]}"; do
+    if grep "${img}" "${TESTFOLDER}/ai-images.txt" "${TESTFOLDER}/ocp-images.txt"; then
+        cat command-output.txt
+        echo "Filtered image found in downloaded image list"
+        exit 1
+    fi
+
+    if ! grep -q "${img}" "${TESTFOLDER}/ignored-images.txt"; then
+        cat command-output.txt
+        echo "Did not find filtered image in ${TESTFOLDER}/ignored-images.txt: ${img}"
+        exit 1
+    fi
+done
+
+exit 0

--- a/regression/regression-test-imgfilter-regex-no-match.sh
+++ b/regression/regression-test-imgfilter-regex-no-match.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Runs image filter file test, filtering with regex with no matches
+#
+
+source /usr/local/bin/regression-suite-common.sh
+
+cat <<EOF > image-filter.yaml
+---
+patterns:
+  - ^qua\b
+EOF
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
+    --filter image-filter.yaml \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+mapping_lines=$(wc -l < "${TESTFOLDER}/mapping.txt")
+downloaded_image_lines=$(sort -u "${TESTFOLDER}/ai-images.txt" "${TESTFOLDER}/ocp-images.txt" | wc -l)
+ignored_image_lines=$(wc -l < "${TESTFOLDER}/ignored-images.txt")
+
+if [ "${ignored_image_lines}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Expected no images to be filtered."
+    exit 1
+fi
+
+if [ "${mapping_lines}" -eq 0 ]; then
+    cat command-output.txt
+    echo "Error: mapping.txt is empty"
+    exit 1
+fi
+
+if [ "${downloaded_image_lines}" -eq 0 ]; then
+    cat command-output.txt
+    echo "Error: Expected ai-images.txt and ocp-images.txt to have images"
+    exit 1
+fi
+
+if [ "$((downloaded_image_lines+ignored_image_lines))" -ne "${mapping_lines}" ]; then
+    cat command-output.txt
+    echo "Error: Expected sum of downloaded and ignored images to match mapping.txt entries"
+    exit 1
+fi
+
+exit 0

--- a/regression/regression-test-imgfilter-regex.sh
+++ b/regression/regression-test-imgfilter-regex.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Runs image filter file test, filtering with regex
+#
+
+source /usr/local/bin/regression-suite-common.sh
+
+cat <<EOF > image-filter.yaml
+---
+patterns:
+  - ^quay\W
+EOF
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
+    --filter image-filter.yaml \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Expected a non-zero value, but got rc=${rc}"
+    exit 1
+fi
+
+mapping_lines=$(wc -l < "${TESTFOLDER}/mapping.txt")
+downloaded_image_lines=$(sort -u "${TESTFOLDER}/ai-images.txt" "${TESTFOLDER}/ocp-images.txt" | wc -l)
+ignored_image_lines=$(wc -l < "${TESTFOLDER}/ignored-images.txt")
+
+if [ "${mapping_lines}" -eq 0 ]; then
+    cat command-output.txt
+    echo "Error: mapping.txt is empty"
+    exit 1
+fi
+
+if [ "${downloaded_image_lines}" -eq 0 ]; then
+    cat command-output.txt
+    echo "Error: Expected ai-images.txt and ocp-images.txt to have images"
+    exit 1
+fi
+
+if [ "$((downloaded_image_lines+ignored_image_lines))" -ne "${mapping_lines}" ]; then
+    cat command-output.txt
+    echo "Error: Expected sum of downloaded and ignored images to match mapping.txt entries"
+    exit 1
+fi
+
+# Verify filtered images show up in ignored-images.txt, but not ai-images.txt or ocp-images.txt
+mapfile -t filtered_images < <( grep -e '^quay\W' "${TESTFOLDER}/mapping.txt" | awk -F'=' '{print $1}' )
+for img in "${filtered_images[@]}"; do
+    if grep "${img}" "${TESTFOLDER}/ai-images.txt" "${TESTFOLDER}/ocp-images.txt"; then
+        cat command-output.txt
+        echo "Filtered image found in downloaded image list"
+        exit 1
+    fi
+
+    if ! grep -q "${img}" "${TESTFOLDER}/ignored-images.txt"; then
+        cat command-output.txt
+        echo "Did not find filtered image in ${TESTFOLDER}/ignored-images.txt: ${img}"
+        exit 1
+    fi
+done
+
+exit 0

--- a/regression/regression-test-invalid-acm-version-format.sh
+++ b/regression/regression-test-invalid-acm-version-format.sh
@@ -18,12 +18,14 @@ rc=$?
 
 # We expect this command to return a non-zero status
 if [ "${rc}" -eq 0 ]; then
+    cat command-output.txt
     echo "Expected a non-zero value, but got rc=${rc}"
     exit 1
 fi
 
 # Check for expected error message
 if ! grep -q "Error: Invalid acm-version specified. X.Y.Z format expected: ${DEFAULT_TEST_ACM_BAD_VERSION_FORMAT}" command-output.txt ; then
+    cat command-output.txt
     echo "Expected error message not found in command output."
     exit 1
 fi

--- a/regression/regression-test-invalid-mce-version-format.sh
+++ b/regression/regression-test-invalid-mce-version-format.sh
@@ -16,12 +16,14 @@ rc=$?
 
 # We expect this command to return a non-zero status
 if [ "${rc}" -eq 0 ]; then
+    cat command-output.txt
     echo "Expected a non-zero value, but got rc=${rc}"
     exit 1
 fi
 
 # Check for expected error message
 if ! grep -q "Error: Invalid mce-version specified. X.Y.Z format expected: ${DEFAULT_TEST_MCE_BAD_VERSION_FORMAT}" command-output.txt ; then
+    cat command-output.txt
     echo "Expected error message not found in command output."
     exit 1
 fi

--- a/regression/regression-test-invalid-version-format.sh
+++ b/regression/regression-test-invalid-version-format.sh
@@ -16,12 +16,14 @@ rc=$?
 
 # We expect this command to return a non-zero status
 if [ "${rc}" -eq 0 ]; then
+    cat command-output.txt
     echo "Expected a non-zero value, but got rc=${rc}"
     exit 1
 fi
 
 # Check for expected error message
 if ! grep -q "Error: Invalid release specified. X.Y.Z format expected: ${DEFAULT_TEST_BAD_VERSION_FORMAT}" command-output.txt ; then
+    cat command-output.txt
     echo "Expected error message not found in command output."
     exit 1
 fi

--- a/regression/regression-test-unavailable-acm-version.sh
+++ b/regression/regression-test-unavailable-acm-version.sh
@@ -18,6 +18,7 @@ rc=$?
 
 # We expect this command to return a non-zero status
 if [ "${rc}" -eq 0 ]; then
+    cat command-output.txt
     echo "Expected a non-zero value, but got rc=${rc}"
     exit 1
 fi
@@ -25,6 +26,7 @@ fi
 # Check for expected error message
 if ! grep -q "advanced-cluster-management version ${DEFAULT_TEST_UNAVAILABLE_VERSION} not found in channel" command-output.txt || \
     ! grep -q 'Version checks failed for 1 operator' command-output.txt ; then
+    cat command-output.txt
     echo "Expected error message not found in command output."
     exit 1
 fi

--- a/regression/regression-test-unavailable-mce-version.sh
+++ b/regression/regression-test-unavailable-mce-version.sh
@@ -16,6 +16,7 @@ rc=$?
 
 # We expect this command to return a non-zero status
 if [ "${rc}" -eq 0 ]; then
+    cat command-output.txt
     echo "Expected a non-zero value, but got rc=${rc}"
     exit 1
 fi
@@ -23,6 +24,7 @@ fi
 # Check for expected error message
 if ! grep -q "multicluster-engine version ${DEFAULT_TEST_UNAVAILABLE_VERSION} not found in channel" command-output.txt || \
     ! grep -q 'Version checks failed for 1 operator' command-output.txt ; then
+    cat command-output.txt
     echo "Expected error message not found in command output."
     exit 1
 fi

--- a/regression/regression-test-unknown-option.sh
+++ b/regression/regression-test-unknown-option.sh
@@ -17,12 +17,14 @@ rc=$?
 
 # We expect this command to return a non-zero status
 if [ "${rc}" -eq 0 ]; then
+    cat command-output.txt
     echo "Expected a non-zero value, but got rc=${rc}"
     exit 1
 fi
 
 # Check for expected error message
 if ! grep -q 'Error: unknown flag: --not-a-valid-option' command-output.txt ; then
+    cat command-output.txt
     echo "Expected error message not found in command output."
     exit 1
 fi


### PR DESCRIPTION
This update adds support for a user-specified list of image filters, provided to the factory-precaching-cli download tool as a yaml file with a list of regular expression patterns. The file is parsed prior to starting the download, compiling each pattern. Prior to download, the mapping.txt file returned by the oc-mirror command is parsed, with each image checked against the list of patterns. If any pattern matches either the image name or tag from the mapping.txt, the image is skipped and added to the ignored-images.txt list file.