### PR TITLE
CNF-7944: Add options for overriding default catalog locations

### DIFF
--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -49,7 +49,7 @@ mirror:
 #          channels:
 #            - name: 'stable'
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ .Channel }}
+    - catalog: {{ .CatalogRedhatOperators }}
       packages:
         - name: multicluster-engine
           channels:
@@ -82,7 +82,7 @@ mirror:
         - name: cluster-logging
           channels:
             - name: 'stable'
-    - catalog: registry.redhat.io/redhat/certified-operator-index:v{{ .Channel }}
+    - catalog: {{ .CatalogCertifiedOperators }}
       packages:
         - name: sriov-fec
           channels:

--- a/docs/downloading.md
+++ b/docs/downloading.md
@@ -10,6 +10,7 @@
     - [Precaching the telco 5G RAN operators](#precaching-the-telco-5g-ran-operators)
     - [Image Filtering](#image-filtering)
     - [Custom precaching for disconnected environments](#custom-precaching-for-disconnected-environments)
+    - [Overriding Operator Catalogs](#overriding-operator-catalogs)
 
 ## Background ##
 
@@ -466,6 +467,26 @@ hand with RHCOS (based on RHEL too). Take that into account when mounting host f
     --img quay.io/alosadag/troubleshoot \
     --du-profile -s \
     --skip-imageset
+ 
+Generating list of pre-cached artifacts...
+...
+```
+
+### Overriding Operator Catalogs ###
+
+The user is able to override the default operator catalogs using the `--catalog-redhat-operators` and `--catalog-certified-operators` options, providing the full path to the corresponding catalog indexes.
+The values specified will replace the `redhat-operator-index` and `certified-operator-index` catalog values in the generated `imageset.yaml`. 
+
+In the previous example, we can use the `--catalog-redhat-operators` and `--catalog-certified-operators` options instead of `--generate-imageset` with manual modifications, assuming no other changes to the
+generated `imageset.yaml` are required.
+
+```console
+# podman run -v /mnt:/mnt -v /root/.docker:/root/.docker -v /etc/pki:/etc/pki --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- \
+    factory-precaching-cli download -r 4.11.5 --acm-version 2.5.4 --mce-version 2.0.4 -f /mnt \
+    --img quay.io/alosadag/troubleshoot \
+    --du-profile -s \
+    --catalog-redhat-operators eko4.cloud.lab.eng.bos.redhat.com:8443/redhat/redhat-operator-index:v4.11 \
+    --catalog-certified-operators eko4.cloud.lab.eng.bos.redhat.com:8443/redhat/certified-operator-index:v4.11
  
 Generating list of pre-cached artifacts...
 ...

--- a/regression/regression-test-specify-catalogs.sh
+++ b/regression/regression-test-specify-catalogs.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# Runs test for specifying catalogs
+#
+
+source /usr/local/bin/regression-suite-common.sh
+
+TEST_CATALOG_REDHAT_OPERATORS="nonexistent.catalog:5000/redhat/redhat-operator-index:v99.99"
+TEST_CATALOG_CERTIFIED_OPERATORS="nonexistent.catalog:5000/redhat/certified-operator-index:v99.99"
+
+# Run the command, capturing the output and RC
+factory-precaching-cli download \
+    --testmode \
+    -f "${TESTFOLDER}" \
+    --mce-version "${DEFAULT_TEST_MCE_RELEASE}" \
+    -r "${DEFAULT_TEST_RELEASE}" \
+    --du-profile \
+    --acm-version "${DEFAULT_TEST_ACM_RELEASE}" \
+    --catalog-redhat-operators "${TEST_CATALOG_REDHAT_OPERATORS}" \
+    --catalog-certified-operators "${TEST_CATALOG_CERTIFIED_OPERATORS}" \
+    --generate-imageset \
+    >& command-output.txt
+rc=$?
+
+# We expect this command to return a zero status
+if [ "${rc}" -ne 0 ]; then
+    cat command-output.txt
+    echo "Command returned rc=${rc}"
+    exit 1
+fi
+
+# Validate imageset.yaml
+if [ ! -f "${TESTFOLDER}/imageset.yaml" ]; then
+    echo "Could not find ${TESTFOLDER}/imageset.yaml"
+    exit 1
+fi
+
+cat <<EOF >expected-imageset.yaml
+
+---
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  platform:
+    channels:
+    - name: stable-${DEFAULT_TEST_RELEASE_Y}
+      minVersion: ${DEFAULT_TEST_RELEASE}
+      maxVersion: ${DEFAULT_TEST_RELEASE}
+  additionalImages:
+#
+# Example operators specification:
+#
+#  operators:
+#    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
+#      full: true
+#      packages:
+#        - name: ptp-operator
+#          channels:
+#            - name: 'stable'
+#        - name: sriov-network-operator
+#          channels:
+#            - name: 'stable'
+#        - name: cluster-logging
+#          channels:
+#            - name: 'stable'
+  operators:
+    - catalog: ${TEST_CATALOG_REDHAT_OPERATORS}
+      packages:
+        - name: multicluster-engine
+          channels:
+            - name: 'stable-2.3'
+            - name: 'stable-${DEFAULT_TEST_MCE_RELEASE_Y}'
+              minVersion: ${DEFAULT_TEST_MCE_RELEASE}
+              maxVersion: ${DEFAULT_TEST_MCE_RELEASE}
+        - name: advanced-cluster-management
+          channels:
+            - name: 'release-${DEFAULT_TEST_ACM_RELEASE_Y}'
+              minVersion: ${DEFAULT_TEST_ACM_RELEASE}
+              maxVersion: ${DEFAULT_TEST_ACM_RELEASE}
+        - name: local-storage-operator
+          channels:
+            - name: 'stable'
+        - name: ptp-operator
+          channels:
+            - name: 'stable'
+        - name: sriov-network-operator
+          channels:
+            - name: 'stable'
+        - name: cluster-logging
+          channels:
+            - name: 'stable'
+    - catalog: ${TEST_CATALOG_CERTIFIED_OPERATORS}
+      packages:
+        - name: sriov-fec
+          channels:
+            - name: 'stable'
+EOF
+
+if ! diff expected-imageset.yaml "${TESTFOLDER}/imageset.yaml" ; then
+    echo "Generated imageset.yaml doesn't match expected content."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Added --catalog-redhat-operators and --catalog-certified-operators options to allow the user to override the default catalog locations with custom values.