### PR TITLE
CNF-8767: Prune operators from template

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -424,7 +424,7 @@ func imageDownload(workerID int, image ImageMapping, folder string) error {
 	if TestMode {
 		fmt.Fprintf(os.Stdout, "TestMode: Creating dummy image file: %s", artifactTar)
 
-		time.Sleep(time.Second * 3) // Sleep 3 seconds before creating file
+		time.Sleep(time.Second * 1) // Sleep 1 second before creating file
 
 		out, err := os.OpenFile(path.Join(folder, artifactTar), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err != nil {

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -82,28 +82,6 @@ mirror:
         - name: cluster-logging
           channels:
             - name: 'stable'
-  {{- if VersionAtLeast .Version "4.12" }}
-        - name: lvms-operator
-          channels:
-            - name: 'stable-{{ .Channel }}'
-  {{- else if VersionAtLeast .Version "4.10" }}
-        - name: odf-lvm-operator
-          channels:
-            - name: 'stable-{{ .Channel }}'
-  {{- end }}
-  {{- if VersionAtLeast .Version "4.10" }}
-        - name: amq7-interconnect-operator
-          channels:
-            - name: '1.10.x'
-        - name: bare-metal-event-relay
-          channels:
-            - name: 'stable'
-  {{- end }}
-  {{- if VersionAtMost .Version "4.10" }}
-        - name: performance-addon-operator
-          channels:
-            - name: '{{ .Channel }}'
-  {{- end }}
     - catalog: registry.redhat.io/redhat/certified-operator-index:v{{ .Channel }}
       packages:
         - name: sriov-fec

--- a/regression/regression-test-du-profile.sh
+++ b/regression/regression-test-du-profile.sh
@@ -82,15 +82,6 @@ mirror:
         - name: cluster-logging
           channels:
             - name: 'stable'
-        - name: lvms-operator
-          channels:
-            - name: 'stable-${DEFAULT_TEST_RELEASE_Y}'
-        - name: amq7-interconnect-operator
-          channels:
-            - name: '1.10.x'
-        - name: bare-metal-event-relay
-          channels:
-            - name: 'stable'
     - catalog: registry.redhat.io/redhat/certified-operator-index:v${DEFAULT_TEST_RELEASE_Y}
       packages:
         - name: sriov-fec


### PR DESCRIPTION
The following operators have been dropped from the template:
- lvms-operator
- amq7-interconnect-operator
- bare-metal-event-relay