### PR TITLE
Update Makefile to allow override of Dockerfile filename

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -34,6 +34,8 @@ make update-resources
 
 The Makefile has variables to support building images for development:
 
+- RUNTIME - local container management too (defaults to podman)
+- DOCKERFILE - Name of Docker file for build (defaults to Dockerfile)
 - REPOOWNER - the registry in quay.io for the image (defaults to openshift-kni)
 - IMAGENAME - the image name (defaults to telco-ran-tools)
 - IMAGETAG - the image tag (defaults to latest)
@@ -42,6 +44,12 @@ To build the image, run the `image` make target, or run the `push` make target t
 
 ```bash
 make REPOOWNER=${USER} push
+```
+
+To build the image using the Dockerfile.dev file, which uses the publicly accessible fedora base image, run:
+
+```bash
+make REPOOWNER=${USER} DOCKERFILE=Dockerfile.dev push
 ```
 
 ## Regression testing

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL ?= /bin/bash
 RUNTIME ?= podman
+DOCKERFILE ?= Dockerfile
 REPOOWNER ?= openshift-kni
 IMAGENAME ?= telco-ran-tools
 IMAGETAG ?= latest
@@ -78,7 +79,7 @@ clean:
 .PHONY: image
 image:
 	@echo "building image"
-	$(RUNTIME) build -f Dockerfile -t quay.io/$(REPOOWNER)/$(IMAGENAME):$(IMAGETAG) .
+	$(RUNTIME) build -f $(DOCKERFILE) -t quay.io/$(REPOOWNER)/$(IMAGENAME):$(IMAGETAG) .
 
 .PHONY: push
 push: image


### PR DESCRIPTION
Updated Makefile to allow a developer to override the Dockerfile filename. This allows for a build using Dockerfile.dev, which uses the publicly accessible fedora image as a base, rather than the formal Dockerfile.

To build using the Dockerfile.dev and push to your own repo, run: make REPOOWNER=myrepo DOCKERFILE=Dockerfile.dev push