### PR TITLE
Reduce default parallelization to 50% from 80%

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -36,8 +36,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// DefaultParallelization set to 80% of available cores.
-var DefaultParallelization = int(float32(runtime.NumCPU()) * 0.8)
+// DefaultParallelization set to 50% of available cores.
+var DefaultParallelization = int(float32(runtime.NumCPU()) * 0.5)
 
 // MaxRequeues is the number of retries allowed for download reattempts.
 const MaxRequeues = 3


### PR DESCRIPTION
The retry mechanism appears to be causing the download tool to hit the maximum number of threads allowed (GOMAXPROCS), causing pthread_create failures in some cases. Until this can be resolved, dropping the default parallelization to 50% will reduce the number of active threads used for downloads, leaving more available for the retry mechanism.

/cc @browsell 